### PR TITLE
feat(rpc): add rpc of getBlockByNumber

### DIFF
--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -3,6 +3,12 @@ import resultFmts from './resultFormatter'
 
 const defaultRPC: CKBComponents.Method[] = [
   {
+    name: 'getBlockByNumber',
+    method: 'get_block_by_number',
+    paramsFormatters: [paramsFmts.toNumber],
+    resultFormatters: resultFmts.toBlock,
+  },
+  {
     name: 'getBlock',
     method: 'get_block',
     paramsFormatters: [paramsFmts.toHash],


### PR DESCRIPTION
Add rpc of getBlockByNumber which requires blockNumber as an input and returns a block promise.

ref: https://github.com/nervosnetwork/ckb/pull/631/files