### PR TITLE
docs: fix typo in readme and type comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ JavaScript SDK for Nervos [CKB](https://github.com/nervosnetwork/ckb).
 
 > _Noteice:_ The ckb process will send stack trace to sentry on Rust panics. This is enabled by default before mainnet, which can be opted out by setting the option dsn to empty in the config file.
 
-## About @nervosnetwokr/ckb-sdk-core
+## About @nervosnetwork/ckb-sdk-core
 
 `@nervosnetwork/ckb-sdk-core` is a SDK implemented by JavaScript, and published in [NPM Registry](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core/), which provides APIs for developers to send requests to the CKB blockchain.
 

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -36,7 +36,7 @@ declare namespace CKBComponents {
 
   /* eslint-disable max-len */
   /**
-   * @typedef Script, lock or unlock script
+   * @typedef Script, lock or type script
    * @description Script, the script model in CKB. CKB scripts use UNIX standard execution environment. Each script binary should contain a main function with the following signature `int main(int argc, char* argv[]);`. CKB will concat `signed_args` and `args`, then use the concatenated array to fill `argc/argv` part, then start the script execution. Upon termination, the executed `main` function here will provide a return code, `0` means the script execution succeeds, other values mean the execution fails.
    * @property args, arguments.
    * @property codeHash, point to its dependency, if the referred dependency is listed in the deps field in a transaction, the codeHash means the hash of the referred cell's data.


### PR DESCRIPTION
'lock or unlock' script => 'lock or type' script