### PR TITLE
merge fixes from rc/v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Travis   | [![Build Status](https://travis-ci.com/nervosnetwork/ckb-sdk-js.svg?branch=master)](https://travis-ci.com/nervosnetwork/ckb-sdk-js)                      | [![Build Status](https://travis-ci.com/nervosnetwork/ckb-sdk-js.svg?branch=develop)](https://travis-ci.com/nervosnetwork/ckb-sdk-js)                       |
 | Coverage | [![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/master/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/master) | [![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/develop/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/develop) |
-| NPM      | [![NPM](https://img.shields.io/npm/v/@nervosnetwork/ckb-sdk-core/latest.svg)](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core)                 | [![NPM](https://img.shields.io/npm/v/@nervosnetwork/ckb-sdk-core.svg)](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core)                          |
 
+[![NPM](https://img.shields.io/npm/v/@nervosnetwork/ckb-sdk-core/latest.svg)](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core)
 [![Telegram Group](https://cdn.rawgit.com/Patrolavia/telegram-badge/8fe3382b/chat.svg)](https://t.me/nervos_ckb_dev)
 ![License](https://img.shields.io/npm/l/@nervosnetwork/ckb-sdk-core.svg)
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.10.2"
+  "version": "0.11.0-alpha.0"
 }

--- a/packages/ckb-cli/package.json
+++ b/packages/ckb-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-cli",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "> TODO: description",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -34,7 +34,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-core": "0.10.2",
+    "@nervosnetwork/ckb-sdk-core": "0.11.0-alpha.0",
     "commander": "2.19.0",
     "inquirer": "6.2.1"
   },

--- a/packages/ckb-sdk-address/package.json
+++ b/packages/ckb-sdk-address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-address",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "Address module for CKB",
   "keywords": [
     "CKB",
@@ -33,7 +33,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.10.2",
-    "@nervosnetwork/ckb-types": "0.10.2"
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-types": "0.11.0-alpha.0"
   }
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "> TODO: description",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -29,9 +29,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.10.2",
-    "@nervosnetwork/ckb-sdk-utils": "0.10.2",
-    "@nervosnetwork/ckb-types": "0.10.2"
+    "@nervosnetwork/ckb-sdk-rpc": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-types": "0.11.0-alpha.0"
   },
   "devDependencies": {
     "@types/crypto-js": "3.1.43"

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "@ckb-sdk rpc module",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -32,11 +32,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.10.2",
-    "axios": "^0.18.0"
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
+    "axios": "0.18.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.10.2",
+    "@nervosnetwork/ckb-types": "0.11.0-alpha.0",
     "@types/crypto-js": "3.1.43"
   },
   "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"

--- a/packages/ckb-sdk-utils/__tests__/ckb-utils.test.js
+++ b/packages/ckb-sdk-utils/__tests__/ckb-utils.test.js
@@ -127,7 +127,7 @@ describe('scriptToHash', () => {
     const fixture = {
       script: {
         version: 0,
-        binaryHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         args: [[1]],
       },
       lockHash: 'dade0e507e27e2a5995cf39c8cf454b6e70fa80d03c1187db7a4cb2c9eab79da',

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "> TODO: description",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.10.2",
+    "@nervosnetwork/ckb-types": "0.11.0-alpha.0",
     "blake2b-wasm": "1.1.7",
     "bs58check": "2.1.2",
     "eth-lib": "0.2.8",

--- a/packages/ckb-sdk-utils/src/index.ts
+++ b/packages/ckb-sdk-utils/src/index.ts
@@ -40,10 +40,10 @@ export const utf8ToBytes = (str: string) => textEncoder.encode(str)
 
 export const utf8ToHex = (str: string) => bytesToHex(utf8ToBytes(str))
 
-export const lockScriptToHash = ({ binaryHash, args }: { binaryHash?: string; args?: (Uint8Array | string)[] }) => {
+export const lockScriptToHash = ({ codeHash, args }: { codeHash?: string; args?: (Uint8Array | string)[] }) => {
   const s = blake2b(32, null, null, PERSONAL)
-  if (binaryHash) {
-    s.update(hexToBytes(binaryHash.replace(/^0x/, '')))
+  if (codeHash) {
+    s.update(hexToBytes(codeHash.replace(/^0x/, '')))
   }
   if (args && args.length) {
     args.forEach(arg => (typeof arg === 'string' ? s.update(hexToBytes(arg)) : s.update(arg)))

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.10.2",
+  "version": "0.11.0-alpha.0",
   "description": "> TODO: description",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -24,7 +24,7 @@
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
   "devDependencies": {
-    "@types/crypto-js": "^3.1.43"
+    "@types/crypto-js": "3.1.43"
   },
   "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
 }


### PR DESCRIPTION
1. merge fixes from rc/v0.11.0
    1. rename binaryHash to codeHash in a utils method
    2. slight update in README
2. merge version update from rc/v0.11.0 which is 0.11.0-alpha.0 now.