### PR TITLE
[ᚬmaster] ci: ignore package-lock.json for deploy docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ playground.ts
 
 #docs
 docs
+# ignore for deploy docs
+package-lock.json
 
 # coverage
 coverage


### PR DESCRIPTION
Ignore the generated package-lock.json in CI, which stopped Buiding.

Ref: https://travis-ci.com/nervosnetwork/ckb-sdk-js/jobs/199900988#L692