### PR TITLE
[ᚬmaster] ci: keep temp dir for building docs on deploying gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_success:
 deploy:
   provider: pages
   local_dir: docs
-  skip_cleanup: false
+  skip_cleanup: true
   github_token: $GITHUB_TOKEN
   keep_history: false
   on:


### PR DESCRIPTION
> Make sure you have skip_cleanup set to true, otherwise Travis CI will delete all the files created
during the build, which will probably delete what you are trying to upload.