### PR TITLE
merge the released v0.11.0 to develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ playground.ts
 
 #docs
 docs
+# ignore for deploy docs
+package-lock.json
 
 # coverage
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_success:
 deploy:
   provider: pages
   local_dir: docs
-  skip_cleanup: false
+  skip_cleanup: true
   github_token: $GITHUB_TOKEN
   keep_history: false
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+
+### Features
+
+* **types:** update basic types in CKB ([71d4e5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/71d4e5))
+* **types:** add shannon as a new capacity unit ([910cc5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/910cc5))
+* **feat:** remove always success wallet ([febb5d](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/febb5d))
+* **rpc:** update rpc interface formatter according to new api ([c0a631](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/c0a631))
+* **feat:** add address module ([c5b532](https://github.com/nervosnetwork/ckb-sdk-js/commit/c5b532))
+
+
+### BREAKING CHANGES
+
+* **feat:** remove always success wallet
+* **types:** update basic types according to ckb-types update
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 

--- a/README.md
+++ b/README.md
@@ -39,21 +39,21 @@ JavaScript SDK for Nervos [CKB](https://github.com/nervosnetwork/ckb).
 
 > Nervos project defines a suite of scalable and interoperable blockchain protocols. Nervos CKB uses those protocols to create a self-evolving distributed network with a novel economic model, data model and more.
 
-> _Noteice:_ The ckb process will send stack trace to sentry on Rust panics. This is enabled by default before mainnet, which can be opted out by setting the option dsn to empty in the config file.
+> _Notice:_ The ckb process will send stack trace to sentry on Rust panics. This is enabled by default before mainnet, which can be opted out by setting the option dsn to empty in the config file.
 
 ## About @nervosnetwork/ckb-sdk-core
 
-`@nervosnetwork/ckb-sdk-core` is a SDK implemented by JavaScript, and published in [NPM Registry](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core/), which provides APIs for developers to send requests to the CKB blockchain.
+`@nervosnetwork/ckb-sdk-core` is an SDK implemented by JavaScript, and published in [NPM Registry](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core/), which provides APIs for developers to send requests to the CKB blockchain.
 
-This SDK can be used both in Browsers and [Node.js](https://nodejs.org) cuz it's source code is implemented by TypeScript, which is a superset of JavaScript and compiled into ES6. For some browsers with old versions, some polyfills might be injected.
+This SDK can be used both in Browsers and [Node.js](https://nodejs.org) as it's source code is implemented by TypeScript, which is a superset of JavaScript and compiled into ES6. For some browsers that have old versions, some polyfills might be injected.
 
 # Prerequisites
 
-We are going to use [yarn](https://yarnpkg.com/) for next steps, which is similar to [npm](https://npmjs.com), feel free to pick one.
+We are going to use [yarn](https://yarnpkg.com/) for the next steps, which is similar to [npm](https://npmjs.com), so feel free to pick one.
 
 For the developers who are interested in contribution.
 
-This project depends on [](https://github.com/bitcoinjs/tiny-secp256k1), which depends on a C library. Due to that, the tiny-secp256k1 might require rebuilding in some cases.
+This project depends on [tiny-secp256k1](https://github.com/bitcoinjs/tiny-secp256k1), which depends on a C library. Due to that, the tiny-secp256k1 might require rebuilding in some cases.
 
 ```sh
 $ yarn rebuild tiny-secp256k1 # rebuild tiny-secp256k1
@@ -64,7 +64,7 @@ If you still encounter problems, please read this guide at [secp256k1-node](http
 # Installation
 
 ```sh
-yarn add @nervosnetwork/ckb-sdk-core # install the sdk into your project
+$ yarn add @nervosnetwork/ckb-sdk-core # install the SDK into your project
 ```
 
 # Modules
@@ -79,7 +79,7 @@ This SDK includes several modules:
 
 Used to create an address object, whose value is the address we are going to use.
 
-Default `address algorithm` is the `pubkeyToAddress` in utils module, which generates it in bech32 format.
+Default `address algorithm` is the `pubkeyToAddress` in utils module, which generates address in bech32 format.
 
 Default rule to generate the address from a public key is:
 
@@ -143,7 +143,7 @@ TypeScript compiles to the PascalCase convention, which listed in this module.
 
 # CORE
 
-All the above modules are integrated into the core module. You can find `rpc`, `utils`, `wallet` in the core instance.
+All the modules above are integrated into the core module. You can find `rpc`, `utils`, `wallet` in the core instance.
 
 > The address module has not been integrated yet, and the wallet module will be removed in the future.
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.11.0-alpha.0"
+  "version": "0.11.0"
 }

--- a/packages/ckb-cli/CHANGELOG.md
+++ b/packages/ckb-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-cli
+
+
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-cli

--- a/packages/ckb-cli/README.md
+++ b/packages/ckb-cli/README.md
@@ -1,11 +1,65 @@
 # `ckb-cli`
 
-> TODO: description
+`@nervosnetwork/ckb-cli` is a command line package based on `@nervosnetwork/ckb-sdk-core`, used to start a Node.js runtime, which has an object named `core` injected. The `core` is the instance of `@nervosnetwork/ckb-sdk-core`.
+
+This project is still under very rapid development, all contributions are welcome.
+
+## Installation
+
+Install the package with [yarn](https://yarnpkg.com/):
+
+```sh
+$ yarn global add @nervosnetwork/ckb-cli
+```
+
+Or install the package with [npm](https://npmjs.com):
+
+```sh
+$ npm install -g @nervosnetwork/ckb-cli
+```
 
 ## Usage
 
-```
-const ckbCli = require('ckb-cli');
-
-// TODO: DEMONSTRATE API
+```sh
+$ @nervosnetwork/ckb-cli <url to the node>
+ckb => connected to <url to the node>
+ckb => await core.rpc.getTipBlockNumber()
+'6905'
+ckb => await core.rpc.getBlockHash('6905')
+'0x89de946313839a8a77749b6218d4d7ab3513910c5ed86040e5f38efd41e566d7'
+ckb => await core.rpc.getBlock('0x89de946313839a8a77749b6218d4d7ab3513910c5ed86040e5f38efd41e566d7')
+{ header:
+   { parentHash:
+      '0xc5e11f1e5bcf589a99b94d9eaeffdccb51e3fbdc3c39561dfc49e6d42740f400',
+     transactionsRoot:
+      '0x993b28a820cea9297da82654c18e99e6469e08c1a14425724e71ed271d0aac0e',
+     proposalsHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+     witnessesRoot:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+     unclesHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+     unclesCount: 0,
+     difficulty: '0x1000',
+     epoch: '4',
+     hash:
+      '0x89de946313839a8a77749b6218d4d7ab3513910c5ed86040e5f38efd41e566d7',
+     number: 6905,
+     seal:
+      { nonce: '17168453808346374945',
+        proof:
+         '0x6c040000e00d0000380f0000c22100002f2900001d2b0000c32b0000fc2c0000743f00008d4600000c480000e46c0000' },
+     timestamp: '1557653980138',
+     version: 0 },
+  uncles: [],
+  transactions:
+   [ { deps: [],
+       inputs: [Array],
+       outputs: [Array],
+       hash:
+        '0x993b28a820cea9297da82654c18e99e6469e08c1a14425724e71ed271d0aac0e',
+       version: 0,
+       witnesses: [] } ],
+  proposals: [] }
+ckb =>
 ```

--- a/packages/ckb-cli/package.json
+++ b/packages/ckb-cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@nervosnetwork/ckb-cli",
-  "version": "0.11.0-alpha.0",
-  "description": "> TODO: description",
+  "version": "0.11.0",
+  "description": "Command line package based on @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "preferGlobal": true,
   "bin": {
-    "ckb-cli": "./lib"
+    "ckb-cli": "./lib/index.js"
   },
   "directories": {
     "lib": "lib",
@@ -34,7 +34,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-core": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-sdk-core": "0.11.0",
     "commander": "2.19.0",
     "inquirer": "6.2.1"
   },
@@ -42,5 +42,5 @@
     "@types/crypto-js": "3.1.43",
     "@types/inquirer": "6.0.0"
   },
-  "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }

--- a/packages/ckb-sdk-address/CHANGELOG.md
+++ b/packages/ckb-sdk-address/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+
+### Features
+
+* **feat:** add address module ([c5b532](https://github.com/nervosnetwork/ckb-sdk-js/commit/c5b532))

--- a/packages/ckb-sdk-address/README.md
+++ b/packages/ckb-sdk-address/README.md
@@ -1,3 +1,55 @@
 # `ckb-sdk-address`
 
-Address module for CKB
+`@nervosnetwork/ckb-sdk-address` is the address module of `@nervosnetwork/ckb-sdk-core`.
+
+Its current responsibility is just to generate an address object, the algorithm will be introduced in an RFC in the near future.
+
+In a nutshell, the address format is similar to [BIP-0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+
+1. this module takes a private key and then calculates the corresponding public key with secp256k1 algorithm;
+2. use blake160 algorithm to hash the public key and get a blake160-ed string;
+3. bech32 the blake160-ed string with three options(prefix, type, binIndex) to get a bech32-formatted address.
+
+Detailed methods could be found in `@nervosnetwork/ckb-sdk-utils`
+
+## Address options
+
+> The meanings of the options will be explained in the RFC.
+
+1. Prefix
+
+   - 'ckb' for the mainnet
+   - 'ckt' for the testnet
+
+2. type
+
+   - '0x00' for wallet build-in binary_hash ref id
+   - '0x01' for binary_hash
+
+3. binIndex
+
+   - 'P2PH'
+
+## Installation
+
+Install the package with [yarn](https://yarnpkg.com/):
+
+```sh
+$ yarn add @nervosnetwork/ckb-cli
+```
+
+Or install the package with [npm](https://npmjs.com):
+
+```sh
+$ npm install --save @nervosnetwork/ckb-cli
+```
+
+## Usage
+
+```javascript
+const Address = require('@nervosnetwork/ckb-sdk-address)`
+
+const privateKey = 'your private key'
+
+const address = new Address(privateKey)
+```

--- a/packages/ckb-sdk-address/package.json
+++ b/packages/ckb-sdk-address/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-sdk-address",
-  "version": "0.11.0-alpha.0",
-  "description": "Address module for CKB",
+  "version": "0.11.0",
+  "description": "Address module of @nervosnetwork/ckb-sdk-core",
   "keywords": [
     "CKB",
     "address"
@@ -33,7 +33,8 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
-    "@nervosnetwork/ckb-types": "0.11.0-alpha.0"
-  }
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0",
+    "@nervosnetwork/ckb-types": "0.11.0"
+  },
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+
+### Features
+
+* **types:** update basic types in CKB ([71d4e5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/71d4e5))
+* **types:** add shannon as a new capacity unit ([910cc5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/910cc5))
+* **feat:** remove always success wallet ([febb5d](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/febb5d))
+* **rpc:** update rpc interface formatter according to new api ([c0a631](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/c0a631))
+* **feat:** add address module ([c5b532](https://github.com/nervosnetwork/ckb-sdk-js/commit/c5b532))
+
+
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-core

--- a/packages/ckb-sdk-core/README.md
+++ b/packages/ckb-sdk-core/README.md
@@ -1,11 +1,7 @@
-# `ckb-core`
+# `ckb-sdk-core`
 
-> TODO: description
+`@nervosnetwork/ckb-sdk-core` is the JavaScript SDK for Nervos Network [CKB Project](https://github.com/nervosnetwork/ckb)
 
-## Usage
+# More Information
 
-```
-const ckbCore = require('ckb-core');
-
-// TODO: DEMONSTRATE API
-```
+[README.md](../../README.md)

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.11.0-alpha.0",
-  "description": "> TODO: description",
+  "version": "0.11.0",
+  "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
   "license": "MIT",
@@ -29,12 +29,12 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.11.0-alpha.0",
-    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
-    "@nervosnetwork/ckb-types": "0.11.0-alpha.0"
+    "@nervosnetwork/ckb-sdk-rpc": "0.11.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0",
+    "@nervosnetwork/ckb-types": "0.11.0"
   },
   "devDependencies": {
     "@types/crypto-js": "3.1.43"
   },
-  "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+
+### Features
+
+* **rpc:** feat(rpc): update rpc interface formatter according to new api ([c0a631](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/c0a631))
+
+
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 

--- a/packages/ckb-sdk-rpc/README.md
+++ b/packages/ckb-sdk-rpc/README.md
@@ -1,11 +1,5 @@
-# `ckb-rpc`
+# `ckb-sdk-rpc`
 
-This is **ckb-sdk** rpc module.
+`@nervosnetwork/ckb-sdk-rpc` is the rpc module of `@nervosnetwork/ckb-sdk-core`.
 
-## Usage
-
-```
-const ckbRpc = require('ckb-rpc');
-
-// TODO: DEMONSTRATE API
-```
+RPC list could be found [here](http://nervosnetwork.github.io/ckb-sdk-js/classes/defaultrpc.html)

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -29,7 +29,7 @@ describe('ckb-rpc success', () => {
 
   it('get peers state', async () => {
     const state = await rpc.getPeersState()
-    expect(state).not.tobe(undefined)
+    expect(state).not.toBe(undefined)
   })
 
   it('get tip block number', async () => {
@@ -151,18 +151,6 @@ describe('ckb-rpc settings and helpers', () => {
 
   it('has 17 default rpc', () => {
     expect(rpc.methods.length).toBe(17)
-  })
-
-  it('has initialized node url of http://localhost:8114', () => {
-    expect(rpc.methods[0].constructor.node.url).toBe('http://localhost:8114')
-  })
-
-  it('set node url to http://test.localhost:8114', () => {
-    const url = 'http://test.localhost:8114'
-    rpc.setNode({
-      url,
-    })
-    expect(rpc.methods[0].constructor.node.url).toBe(url)
   })
 
   it('has initialized node url of http://localhost:8114', () => {

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -165,6 +165,18 @@ describe('ckb-rpc settings and helpers', () => {
     expect(rpc.methods[0].constructor.node.url).toBe(url)
   })
 
+  it('has initialized node url of http://localhost:8114', () => {
+    expect(rpc.methods[0].constructor.node.url).toBe('http://localhost:8114')
+  })
+
+  it('set node url to http://test.localhost:8114', () => {
+    const url = 'http://test.localhost:8114'
+    rpc.setNode({
+      url,
+    })
+    expect(rpc.methods[0].constructor.node.url).toBe(url)
+  })
+
   it(`set debug level to ${DebugLevel.Off}`, async () => {
     const info = jest.spyOn(global.console, 'info')
     const group = jest.spyOn(global.console, 'group')

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.11.0-alpha.0",
-  "description": "@ckb-sdk rpc module",
+  "version": "0.11.0",
+  "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
   "license": "MIT",
@@ -32,12 +32,12 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.11.0",
     "axios": "0.18.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-types": "0.11.0",
     "@types/crypto-js": "3.1.43"
   },
-  "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-wallet
+
+
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 

--- a/packages/ckb-sdk-utils/README.md
+++ b/packages/ckb-sdk-utils/README.md
@@ -1,21 +1,3 @@
-# `ckb-utils`
+# `ckb-sdk-utils`
 
-> TODO: description
-
-## Usage
-
-```
-const ckbUtils = require('ckb-utils');
-
-// TODO: DEMONSTRATE API
-```
-
-## Troubleshooting
-
-### Failed due to `tiny-secp256k1`
-
-> dyld: lazy symbol binding failed: Symbol not found: \_\_ZN2v811HandleScope12CreateHandleEPNS_8internal10HeapObjectEPNS1_6ObjectE
-> Referenced from: /path/to/neuron/node_modules/tiny-secp256k1/build/Release/secp256k1.node
-> Expected in: flat namespace
-
-This comes with different node version on building, `npm rebuild tiny-secp256k1` in this package to fix it.
+`@nervosnetwork/ckb-sdk-utils` is the utils module of `@nervosnetwork/ckb-sdk-core`, which provides necessary methods for the sdk, including encryption, key-pair generation, address generation and so on.

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.11.0-alpha.0",
-  "description": "> TODO: description",
+  "version": "0.11.0",
+  "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.11.0-alpha.0",
+    "@nervosnetwork/ckb-types": "0.11.0",
     "blake2b-wasm": "1.1.7",
     "bs58check": "2.1.2",
     "eth-lib": "0.2.8",
@@ -42,5 +42,5 @@
     "@types/tiny-secp256k1": "1.0.0",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.11.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.10.0...v0.11.0) (2019-05-14)
+
+
+### Features
+
+* **types:** update basic types in CKB ([71d4e5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/71d4e5))
+* **types:** set the type of arg in script to string ([2aaa75](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/2aaa75))
+* **types:** add shannon as a new capacity unit ([910cc5](https://github.com/nervosnetwork/ckb-sdk-js/pull/135/commits/910cc5))
+
+
+### BREAKING CHANGES
+
+* **types:** update basic types according to ckb-types update
+
+
+
+
+
+
 # [0.10.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.9.0...v0.10.0) (2019-05-06)
 
 

--- a/packages/ckb-types/README.md
+++ b/packages/ckb-types/README.md
@@ -1,11 +1,3 @@
 # `ckb-types`
 
-> TODO: description
-
-## Usage
-
-```
-const ckbTypes = require('ckb-types');
-
-// TODO: DEMONSTRATE API
-```
+`@nervosnetwork/ckb-types` is the type definition module for the `@nervosnetwork/ckb-sdk-core` and its modules.

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.11.0-alpha.0",
-  "description": "> TODO: description",
+  "version": "0.11.0",
+  "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
   "license": "MIT",
@@ -26,5 +26,5 @@
   "devDependencies": {
     "@types/crypto-js": "3.1.43"
   },
-  "gitHead": "7b8b74a4501ce3999090f610dd4a371da6c8ceaa"
+  "gitHead": "55819ad5bb85b21082adf7630658368c785e2a41"
 }


### PR DESCRIPTION
1. merge v0.11.0 to develop branch

2. remove wallet module which has been removed in the current develop branch but imported by v0.11.0

3. remove redundant test cases which imported by v0.11.0