### PR TITLE
feat(core): add the address config parameter in the generateAddress m…

### DIFF
--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -62,11 +62,18 @@ class Core {
     return this._utils
   }
 
-  public generateAddress = (privateKey: string) =>
-    new Address(privateKey, {
+  public generateAddress = (
+    privateKey: string,
+    { prefix = utils.AddressPrefix.Mainnet, type = utils.AddressType.BinIdx, binIdx = utils.AddressBinIdx.P2PH } = {
       prefix: utils.AddressPrefix.Mainnet,
       type: utils.AddressType.BinIdx,
       binIdx: utils.AddressBinIdx.P2PH,
+    }
+  ) =>
+    new Address(privateKey, {
+      prefix,
+      type,
+      binIdx,
     })
 
   public loadSystemCell = async () => {


### PR DESCRIPTION
…ethod of the core module

add the address configuration composed of `prefix`, `type`, and `binIdx` as the optional second parameter in the `generateAddress` method of the core module.