### PR TITLE
docs(core): fix the example of sending transactions

### DIFF
--- a/packages/ckb-sdk-core/examples/sendTransaction.js
+++ b/packages/ckb-sdk-core/examples/sendTransaction.js
@@ -82,7 +82,7 @@ const bootstrap = async () => {
               console.log(`Fetched from ${from} to ${from + STEP} with ${cells.length} cells`)
             }
             cellsGroup.push(cells)
-            return getUnspentCells(_lockHash, from + STEP, to, cb)
+            return getUnspentCells(_lockHash, from + STEP + 1, to, cb)
           })
           .catch(reject)
       }


### PR DESCRIPTION
fix the get unspent cells method

`getUnspentCells` returns cells from [from, to] inclusively, so the next iteration should start from `to+1`