### PR TITLE
feat(rpc): use bigint instead of number in the interfaces of rpc methods

### DIFF
--- a/packages/ckb-sdk-rpc/__tests__/formatters/params.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/params.fixtures.json
@@ -6,15 +6,15 @@
     },
     {
       "param": 20,
-      "expected": "0x14"
+      "exception": "The number 20 should be a bigint or a hex string"
     },
     {
       "param": null,
-      "exception": "The number null should be a number or a hex string"
+      "exception": "The number null should be a bigint or a hex string"
     },
     {
       "param": "1",
-      "exception": "If the number 1 is a hex string, please prefix it with 0x"
+      "exception": "Hex string 1 should start with 0x"
     }
   ],
   "toHash": [
@@ -120,7 +120,7 @@
     {
       "param": {
         "previousOutput": null,
-        "since": 0
+        "since": "0x0"
       },
       "expected": {
         "previous_output": null,
@@ -298,10 +298,6 @@
       "expected": "0x12"
     },
     {
-      "param": 12,
-      "expected": "0xc"
-    },
-    {
       "expected": "0x1"
     }
   ],
@@ -311,18 +307,22 @@
       "expected": "0x12"
     },
     {
-      "param": 12,
-      "expected": "0xc"
-    },
-    {
       "expected": "0x32"
     },
     {
-      "param": "-1",
-      "exception": "Page size is expected to be positive"
+      "param": 0,
+      "expected": "0x0"
     },
     {
-      "param": "51",
+      "param": -1,
+      "exception": "Page size is expected to be non-negative"
+    },
+    {
+      "param": 50,
+      "expected": "0x32"
+    },
+    {
+      "param": 51,
       "exception": "Page size is up to 50"
     }
   ],

--- a/packages/ckb-sdk-rpc/__tests__/formatters/params.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/params.test.js
@@ -21,7 +21,7 @@ describe('params formatter', () => {
 
   describe('toOptional', () => {
     it('toOptional with other format should return the formatted value', () => {
-      expect(paramsFmt.toOptional(paramsFmt.toNumber)(20)).toBe('0x14')
+      expect(paramsFmt.toOptional(paramsFmt.toNumber)(BigInt(20))).toBe('0x14')
     })
 
     it("toOptional with other format should return the raw value if it's undefined or null", () => {
@@ -34,9 +34,7 @@ describe('params formatter', () => {
     })
 
     it('toOptional should throw errors which are thrown from other format', () => {
-      expect(() => paramsFmt.toOptional(paramsFmt.toNumber)('20')).toThrow(
-        'If the number 20 is a hex string, please prefix it with 0x'
-      )
+      expect(() => paramsFmt.toOptional(paramsFmt.toNumber)('20')).toThrow('Hex string 20 should start with 0x')
     })
   })
 })

--- a/packages/ckb-sdk-rpc/src/paramsFormatter.ts
+++ b/packages/ckb-sdk-rpc/src/paramsFormatter.ts
@@ -1,3 +1,4 @@
+import { HexStringShouldStartWith0x } from '@nervosnetwork/ckb-sdk-utils/lib/exceptions'
 /* eslint-disable camelcase */
 const formatter = {
   toOptional: (format?: Function) => (arg: any) => {
@@ -12,15 +13,15 @@ const formatter = {
     }
     return hash.startsWith('0x') ? hash : `0x${hash}`
   },
-  toNumber: (number: CKBComponents.Number | number): CKB_RPC.Number => {
-    if (typeof number === 'number') {
+  toNumber: (number: CKBComponents.Number | bigint): CKB_RPC.Number => {
+    if (typeof number === 'bigint') {
       return `0x${number.toString(16)}`
     }
     if (typeof number !== 'string') {
-      throw new TypeError(`The number ${number} should be a number or a hex string`)
+      throw new TypeError(`The number ${number} should be a bigint or a hex string`)
     }
     if (!number.startsWith('0x')) {
-      throw new Error(`If the number ${number} is a hex string, please prefix it with 0x`)
+      throw new HexStringShouldStartWith0x(number)
     }
     return number
   },
@@ -100,11 +101,11 @@ const formatter = {
     }
     return tx
   },
-  toPageNumber: (pageNo: string | number = '0x1') => formatter.toNumber(pageNo),
-  toPageSize: (pageSize: string | number = 50) => {
-    const size = +pageSize || 50
-    if (size > 50) throw new Error('Page size is up to 50')
-    if (size < 0) throw new Error('Page size is expected to be positive')
+  toPageNumber: (pageNo: string | bigint = '0x1') => formatter.toNumber(pageNo),
+  toPageSize: (pageSize: string | bigint = '0x32') => {
+    const size = BigInt(pageSize)
+    if (size > BigInt(50)) throw new Error('Page size is up to 50')
+    if (size < BigInt(0)) throw new Error('Page size is expected to be non-negative')
     return formatter.toNumber(size)
   },
   toReverseOrder: (reverse: boolean = false) => !!reverse,


### PR DESCRIPTION
allow bigit and forbid number type

BREAKING CHANGE: use bigint instead of number in the interfaces of rpc methods