### PR TITLE
feat(address): add support to addresses in full version format

### DIFF
--- a/packages/ckb-sdk-core/src/address.ts
+++ b/packages/ckb-sdk-core/src/address.ts
@@ -13,7 +13,7 @@ class Address extends ECPair {
       addressAlgorithm = pubkeyToAddress,
       prefix = AddressPrefix.Testnet,
       type = AddressType.HashIdx,
-      codeHashIndex = '0x00',
+      codeHashOrCodeHashIndex = '0x00',
     }: Partial<
       {
         addressAlgorithm: Function
@@ -22,14 +22,14 @@ class Address extends ECPair {
       addressAlgorithm: pubkeyToAddress,
       prefix: AddressPrefix.Testnet,
       type: AddressType.HashIdx,
-      codeHashIndex: '0x00',
+      codeHashOrCodeHashIndex: '0x00',
     }
   ) {
     super(sk)
     this.value = addressAlgorithm(this.publicKey, {
       prefix,
       type,
-      codeHashIndex,
+      codeHashOrCodeHashIndex,
     })
     this.publicKeyHash = `0x${blake160(this.publicKey as string, 'hex')}`
   }

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -73,16 +73,16 @@ class Core {
 
   public generateAddress = (
     privateKey: string,
-    { prefix = utils.AddressPrefix.Testnet, type = utils.AddressType.HashIdx, codeHashIndex = '0x00' } = {
+    { prefix = utils.AddressPrefix.Testnet, type = utils.AddressType.HashIdx, codeHashOrCodeHashIndex = '0x00' } = {
       prefix: utils.AddressPrefix.Testnet,
       type: utils.AddressType.HashIdx,
-      codeHashIndex: '0x00',
+      codeHashOrCodeHashIndex: '0x00',
     }
   ) =>
     new Address(privateKey, {
       prefix,
       type,
-      codeHashIndex,
+      codeHashOrCodeHashIndex,
     })
 
   public generateLockHash = (

--- a/packages/ckb-sdk-utils/__tests__/utils/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/utils/index.test.js
@@ -21,6 +21,8 @@ const {
   rawTransactionToHash,
   PERSONAL,
   toHexInLittleEndian,
+  AddressType,
+  fullPayloadToAddress,
 } = ckbUtils
 
 const { HexStringShouldStartWith0x, InvalidHexString } = exceptions
@@ -202,6 +204,46 @@ describe('address', () => {
     }
     const payload = bytesToHex(toAddressPayload(fixture.publicKeyHash))
     expect(payload).toBe(fixture.payload)
+  })
+
+  it('fullPayloadToAddress with hash type of Data', () => {
+    const fixture = {
+      params: {
+        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        type: AddressType.DataCodeHash,
+        prefix: 'ckt',
+        codeHash: '0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176',
+      },
+      expected: 'ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac',
+    }
+    const address = fullPayloadToAddress(fixture.params)
+    expect(address).toBe(fixture.expected)
+  })
+
+  it('fullPayloadToAddress with hash type of Type', () => {
+    const fixture = {
+      params: {
+        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        type: AddressType.TypeCodeHash,
+        prefix: 'ckt',
+        codeHash: '0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2',
+      },
+      expected: 'ckt1qsvf96jqmq4483ncl7yrzfzshwchu9jd0glq4yy5r2jcsw04d7xlydkr98kkxrtvuag8z2j8w4pkw2k6k4l5c02auef',
+    }
+    const address = fullPayloadToAddress(fixture.params)
+    expect(address).toBe(fixture.expected)
+  })
+
+  it('fullPayloadToAddress with default params of type = AddressType.DataCodeHash and prefix = ckt', () => {
+    const fixture = {
+      params: {
+        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        codeHash: '0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176',
+      },
+      expected: 'ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac',
+    }
+    const address = fullPayloadToAddress(fixture.params)
+    expect(address).toBe(fixture.expected)
   })
 
   it('publicKeyHash to address with prefix of ckt', () => {

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -30,7 +30,7 @@ export const defaultAddressOptions = {
 /**
  * @function toAddressPayload
  * @description payload = type(01) | code hash index(00) | args(blake160-formatted pubkey)
- * @see https://github.com/nervosnetwork/ckb/wiki/Common-Address-Format
+ * @see https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
  * @param {string | Uint8Array} args, use as the identifier of an address, usually the public key hash is used.
  * @param {string} type, used to indicate which format is adopted to compose the address.
  * @param {string} codeHashOrCodeHashIndex, the referenced code hash or code hash index the address binds to

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -29,24 +29,24 @@ export const defaultAddressOptions = {
 
 /**
  * @function toAddressPayload
- * @description payload = type(01) | code hash index(00) | blake160-formatted pubkey
+ * @description payload = type(01) | code hash index(00) | args(blake160-formatted pubkey)
  * @see https://github.com/nervosnetwork/ckb/wiki/Common-Address-Format
- * @param {string | Uint8Array} arg, use as the identifier of an address, usually the public key hash is used.
+ * @param {string | Uint8Array} args, use as the identifier of an address, usually the public key hash is used.
  * @param {string} type, used to indicate which format is adopted to compose the address.
  * @param {string} codeHashOrCodeHashIndex, the referenced code hash or code hash index the address binds to
  */
 export const toAddressPayload = (
-  arg: string | Uint8Array,
+  args: string | Uint8Array,
   type: AddressType = AddressType.HashIdx,
   codeHashOrCodeHashIndex: CodeHashIndex | CKBComponents.Hash256 = '0x00'
 ): Uint8Array => {
-  if (typeof arg === 'string') {
-    if (!arg.startsWith('0x')) {
-      throw new HexStringShouldStartWith0x(arg)
+  if (typeof args === 'string') {
+    if (!args.startsWith('0x')) {
+      throw new HexStringShouldStartWith0x(args)
     }
-    return new Uint8Array([...hexToBytes(type), ...hexToBytes(codeHashOrCodeHashIndex), ...hexToBytes(arg)])
+    return new Uint8Array([...hexToBytes(type), ...hexToBytes(codeHashOrCodeHashIndex), ...hexToBytes(args)])
   }
-  return new Uint8Array([...hexToBytes(type), ...hexToBytes(codeHashOrCodeHashIndex), ...arg])
+  return new Uint8Array([...hexToBytes(type), ...hexToBytes(codeHashOrCodeHashIndex), ...args])
 }
 
 /**

--- a/packages/ckb-sdk-utils/src/crypto/bech32.ts
+++ b/packages/ckb-sdk-utils/src/crypto/bech32.ts
@@ -1,7 +1,5 @@
 const ALPHABET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
 
-const LIMIT = 90
-
 const SEPARATOR = '1'
 
 const alphabetMap = new Map<string, number>()
@@ -47,10 +45,8 @@ const prefixChecksum = (prefix: string) => {
   return checksum
 }
 
-export const encode = (prefix: string, words: Uint8Array, limit: number = LIMIT) => {
+export const encode = (prefix: string, words: Uint8Array) => {
   const formattedPrefix = prefix.toLowerCase()
-
-  if (formattedPrefix.length + 7 + words.length > limit) throw new TypeError('Exceeds length limit')
 
   // determine checksum mod
   let checksum = prefixChecksum(formattedPrefix)
@@ -80,7 +76,7 @@ export const encode = (prefix: string, words: Uint8Array, limit: number = LIMIT)
   return result
 }
 
-export const decode = (encoded: string, limit: number = LIMIT) => {
+export const decode = (encoded: string) => {
   const lowered = encoded.toLowerCase()
 
   const uppered = encoded.toUpperCase()
@@ -90,8 +86,6 @@ export const decode = (encoded: string, limit: number = LIMIT) => {
   const str = lowered
 
   if (str.length < 8) throw new TypeError(`${str} too short`)
-
-  if (str.length > limit) throw new TypeError('Exceeds length limit')
 
   const split = str.lastIndexOf(SEPARATOR)
 


### PR DESCRIPTION
1. add a new method to generate full version addresses
2. rename an parameter in bech32Address method from codeHashIndex to codeHashOrCodeHashIndex

BREAKING CHANGE: rename an parameter in bech32Address method from codeHash to codeHashOrCodeHashIndex