### PR TITLE
fix(rpc): update the signatures of rpc methods

### DIFF
--- a/packages/ckb-sdk-core/__tests__/loadCells/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/loadCells/fixtures.json
@@ -93,24 +93,6 @@
     },
     "exception": "Hex string 12c should start with 0x"
   },
-  "parameters including invalid integer of start should throw an error": {
-    "params": {
-      "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-      "start": 1.1,
-      "end": "0x12c",
-      "STEP": 100
-    },
-    "exception": "1.1 cannot be converted into an integer"
-  },
-  "parameters including invalid integer of end should throw an error": {
-    "params": {
-      "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-      "start": "0x1",
-      "end": 1.1,
-      "STEP": 100
-    },
-    "exception": "1.1 cannot be converted into an integer"
-  },
   "end less than start should throw an error": {
     "params": {
       "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",

--- a/packages/ckb-sdk-core/__tests__/loadCells/index.test.js
+++ b/packages/ckb-sdk-core/__tests__/loadCells/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const { default: loadCells } = require('../../lib/loadCells')
 const rpc = require('../../__mocks__/rpc')
 const fixtures = require('./fixtures.json')
@@ -11,6 +12,20 @@ describe('load cells', () => {
     exception,
   ])
   test.each(fixtureTable)('%s case: %j', async (_title, params, expectedCells, expectedCalls, exception) => {
+    Object.keys(params).forEach(key => {
+      if (typeof params[key] === 'number') {
+        params[key] = BigInt(params[key])
+      }
+    })
+    if (expectedCalls) {
+      expectedCalls.forEach(call => {
+        call.forEach((v, i) => {
+          if (typeof v === 'number') {
+            call[i] = BigInt(v)
+          }
+        })
+      })
+    }
     rpc.getCellsByLockHash.mockClear()
     if (undefined === exception) {
       const cells = await loadCells({

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -137,15 +137,15 @@ class Core {
 
   public loadCells = async ({
     lockHash,
-    start = 0,
+    start = BigInt(0),
     end,
-    STEP = 100,
+    STEP = BigInt(100),
     save = false,
   }: {
     lockHash: string
-    start?: string | number
-    end?: string | number
-    STEP?: number
+    start?: string | bigint
+    end?: string | bigint
+    STEP?: bigint
     save?: boolean
   }) => {
     const cells = await loadCells({ lockHash, start, end, STEP, rpc: this.rpc })

--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -172,7 +172,7 @@ export class DefaultRPC {
    * @param {string} number - the block number of the target block
    * @returns {Promise<object>} block object
    */
-  public getBlockByNumber!: (number: CKBComponents.BlockNumber | number) => Promise<CKBComponents.Block>
+  public getBlockByNumber!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Block>
 
   /**
    * @method getBlockByNumber
@@ -199,7 +199,7 @@ export class DefaultRPC {
    * @param {string} hash - block hash
    * @return {Promise<string>} block hash
    */
-  public getBlockHash!: (number: CKBComponents.BlockNumber | number) => Promise<CKBComponents.Hash>
+  public getBlockHash!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Hash>
 
   /**
    * @method getTipHeader
@@ -221,8 +221,8 @@ export class DefaultRPC {
    */
   public getCellsByLockHash!: (
     hash: CKBComponents.Hash256,
-    from: CKBComponents.BlockNumber | number,
-    to: CKBComponents.BlockNumber | number
+    from: CKBComponents.BlockNumber | bigint,
+    to: CKBComponents.BlockNumber | bigint
   ) => Promise<CKBComponents.CellIncludingOutPoint[]>
 
   /**
@@ -317,7 +317,7 @@ export class DefaultRPC {
    * @description rpc to get the epoch info by its number
    * @return {Promise<object>} epoch info
    */
-  public getEpochByNumber!: (epoch: string | number) => Promise<CKBComponents.Epoch>
+  public getEpochByNumber!: (epoch: string | bigint) => Promise<CKBComponents.Epoch>
 
   /**
    * @method dryRunTransaction
@@ -352,8 +352,8 @@ export class DefaultRPC {
    */
   public getLiveCellsByLockHash!: (
     lockHash: CKBComponents.Hash256,
-    pageNumber: string | number,
-    pageSize: string | number,
+    pageNumber: string | bigint,
+    pageSize: string | bigint,
     reverseOrder?: boolean
   ) => Promise<CKBComponents.LiveCellsByLockHash>
 
@@ -378,8 +378,8 @@ export class DefaultRPC {
    */
   public getTransactionsByLockHash!: (
     lockHash: CKBComponents.Hash256,
-    pageNumber: string | number,
-    pageSize: string | number,
+    pageNumber: string | bigint,
+    pageSize: string | bigint,
     reverseOrder?: boolean
   ) => Promise<CKBComponents.TransactionsByLockHash>
 
@@ -438,7 +438,7 @@ export class DefaultRPC {
    * @description Returns the information about a block header by block number
    * @params {string} block number
    */
-  public getHeaderByNumber!: (blockNumber: CKBComponents.BlockNumber | number) => Promise<CKBComponents.BlockHeader>
+  public getHeaderByNumber!: (blockNumber: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.BlockHeader>
 
   /**
    * @method getCellbaseOutputCapacityDetails


### PR DESCRIPTION
use bigint instead of number in signatures of rpc methods

BREAKING CHANGE: use bigint instead of number in signatures of rpc methods

re #363, fix #365