### PR TITLE
[ᚬmaster] Rc/v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)
+
+
+### Bug Fixes
+
+* **rpc:** update the signatures of rpc methods ([7eb6726](https://github.com/nervosnetwork/ckb-sdk-js/commit/7eb6726)), closes [#365](https://github.com/nervosnetwork/ckb-sdk-js/issues/365)
+
+
+### BREAKING CHANGES
+
+* **rpc:** use bigint instead of number in signatures of rpc methods
+
+
+
+
+
 # [0.22.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.21.1...v0.22.0) (2019-10-05)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.22.0"
+  "version": "0.22.1"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)
+
+
+### Bug Fixes
+
+* **rpc:** update the signatures of rpc methods ([7eb6726](https://github.com/nervosnetwork/ckb-sdk-js/commit/7eb6726)), closes [#365](https://github.com/nervosnetwork/ckb-sdk-js/issues/365)
+
+
+### BREAKING CHANGES
+
+* **rpc:** use bigint instead of number in signatures of rpc methods
+
+
+
+
+
 # [0.22.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.21.1...v0.22.0) (2019-10-05)
 
 

--- a/packages/ckb-sdk-core/__tests__/loadCells/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/loadCells/fixtures.json
@@ -93,24 +93,6 @@
     },
     "exception": "Hex string 12c should start with 0x"
   },
-  "parameters including invalid integer of start should throw an error": {
-    "params": {
-      "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-      "start": 1.1,
-      "end": "0x12c",
-      "STEP": 100
-    },
-    "exception": "1.1 cannot be converted into an integer"
-  },
-  "parameters including invalid integer of end should throw an error": {
-    "params": {
-      "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-      "start": "0x1",
-      "end": 1.1,
-      "STEP": 100
-    },
-    "exception": "1.1 cannot be converted into an integer"
-  },
   "end less than start should throw an error": {
     "params": {
       "lockHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",

--- a/packages/ckb-sdk-core/__tests__/loadCells/index.test.js
+++ b/packages/ckb-sdk-core/__tests__/loadCells/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const { default: loadCells } = require('../../lib/loadCells')
 const rpc = require('../../__mocks__/rpc')
 const fixtures = require('./fixtures.json')
@@ -11,6 +12,20 @@ describe('load cells', () => {
     exception,
   ])
   test.each(fixtureTable)('%s case: %j', async (_title, params, expectedCells, expectedCalls, exception) => {
+    Object.keys(params).forEach(key => {
+      if (typeof params[key] === 'number') {
+        params[key] = BigInt(params[key])
+      }
+    })
+    if (expectedCalls) {
+      expectedCalls.forEach(call => {
+        call.forEach((v, i) => {
+          if (typeof v === 'number') {
+            call[i] = BigInt(v)
+          }
+        })
+      })
+    }
     rpc.getCellsByLockHash.mockClear()
     if (undefined === exception) {
       const cells = await loadCells({

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -34,5 +34,5 @@
     "@nervosnetwork/ckb-sdk-utils": "0.22.1",
     "@nervosnetwork/ckb-types": "0.22.1"
   },
-  "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"
+  "gitHead": "75ca98410be660b343f79a8f56380b218ac0ed1a"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -30,9 +30,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.22.0",
-    "@nervosnetwork/ckb-sdk-utils": "0.22.0",
-    "@nervosnetwork/ckb-types": "0.22.0"
+    "@nervosnetwork/ckb-sdk-rpc": "0.22.1",
+    "@nervosnetwork/ckb-sdk-utils": "0.22.1",
+    "@nervosnetwork/ckb-types": "0.22.1"
   },
   "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"
 }

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -137,15 +137,15 @@ class Core {
 
   public loadCells = async ({
     lockHash,
-    start = 0,
+    start = BigInt(0),
     end,
-    STEP = 100,
+    STEP = BigInt(100),
     save = false,
   }: {
     lockHash: string
-    start?: string | number
-    end?: string | number
-    STEP?: number
+    start?: string | bigint
+    end?: string | bigint
+    STEP?: bigint
     save?: boolean
   }) => {
     const cells = await loadCells({ lockHash, start, end, STEP, rpc: this.rpc })

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)
+
+
+### Bug Fixes
+
+* **rpc:** update the signatures of rpc methods ([7eb6726](https://github.com/nervosnetwork/ckb-sdk-js/commit/7eb6726)), closes [#365](https://github.com/nervosnetwork/ckb-sdk-js/issues/365)
+
+
+### BREAKING CHANGES
+
+* **rpc:** use bigint instead of number in signatures of rpc methods
+
+
+
+
+
 # [0.22.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.21.1...v0.22.0) (2019-10-05)
 
 

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -32,11 +32,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.22.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.22.1",
     "axios": "0.19.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.22.0",
+    "@nervosnetwork/ckb-types": "0.22.1",
     "dotenv": "8.1.0"
   },
   "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -39,5 +39,5 @@
     "@nervosnetwork/ckb-types": "0.22.1",
     "dotenv": "8.1.0"
   },
-  "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"
+  "gitHead": "75ca98410be660b343f79a8f56380b218ac0ed1a"
 }

--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -172,7 +172,7 @@ export class DefaultRPC {
    * @param {string} number - the block number of the target block
    * @returns {Promise<object>} block object
    */
-  public getBlockByNumber!: (number: CKBComponents.BlockNumber | number) => Promise<CKBComponents.Block>
+  public getBlockByNumber!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Block>
 
   /**
    * @method getBlockByNumber
@@ -199,7 +199,7 @@ export class DefaultRPC {
    * @param {string} hash - block hash
    * @return {Promise<string>} block hash
    */
-  public getBlockHash!: (number: CKBComponents.BlockNumber | number) => Promise<CKBComponents.Hash>
+  public getBlockHash!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Hash>
 
   /**
    * @method getTipHeader
@@ -221,8 +221,8 @@ export class DefaultRPC {
    */
   public getCellsByLockHash!: (
     hash: CKBComponents.Hash256,
-    from: CKBComponents.BlockNumber | number,
-    to: CKBComponents.BlockNumber | number
+    from: CKBComponents.BlockNumber | bigint,
+    to: CKBComponents.BlockNumber | bigint
   ) => Promise<CKBComponents.CellIncludingOutPoint[]>
 
   /**
@@ -317,7 +317,7 @@ export class DefaultRPC {
    * @description rpc to get the epoch info by its number
    * @return {Promise<object>} epoch info
    */
-  public getEpochByNumber!: (epoch: string | number) => Promise<CKBComponents.Epoch>
+  public getEpochByNumber!: (epoch: string | bigint) => Promise<CKBComponents.Epoch>
 
   /**
    * @method dryRunTransaction
@@ -352,8 +352,8 @@ export class DefaultRPC {
    */
   public getLiveCellsByLockHash!: (
     lockHash: CKBComponents.Hash256,
-    pageNumber: string | number,
-    pageSize: string | number,
+    pageNumber: string | bigint,
+    pageSize: string | bigint,
     reverseOrder?: boolean
   ) => Promise<CKBComponents.LiveCellsByLockHash>
 
@@ -378,8 +378,8 @@ export class DefaultRPC {
    */
   public getTransactionsByLockHash!: (
     lockHash: CKBComponents.Hash256,
-    pageNumber: string | number,
-    pageSize: string | number,
+    pageNumber: string | bigint,
+    pageSize: string | bigint,
     reverseOrder?: boolean
   ) => Promise<CKBComponents.TransactionsByLockHash>
 
@@ -438,7 +438,7 @@ export class DefaultRPC {
    * @description Returns the information about a block header by block number
    * @params {string} block number
    */
-  public getHeaderByNumber!: (blockNumber: CKBComponents.BlockNumber | number) => Promise<CKBComponents.BlockHeader>
+  public getHeaderByNumber!: (blockNumber: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.BlockHeader>
 
   /**
    * @method getCellbaseOutputCapacityDetails

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 # [0.22.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.21.1...v0.22.0) (2019-10-05)
 
 

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.22.0",
+    "@nervosnetwork/ckb-types": "0.22.1",
     "blake2b-wasm": "1.1.7",
     "elliptic": "6.5.1"
   },

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -39,5 +39,5 @@
     "@types/elliptic": "6.4.8",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"
+  "gitHead": "75ca98410be660b343f79a8f56380b218ac0ed1a"
 }

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 # [0.22.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.21.1...v0.22.0) (2019-10-05)
 
 

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "360e95437fad0599a10d270f1192f5bdb94887eb"
+  "gitHead": "75ca98410be660b343f79a8f56380b218ac0ed1a"
 }


### PR DESCRIPTION
## [0.22.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.22.0...v0.22.1) (2019-10-12)


### Bug Fixes

* **rpc:** update the signatures of rpc methods ([7eb6726](https://github.com/nervosnetwork/ckb-sdk-js/commit/7eb6726)), closes [#365](https://github.com/nervosnetwork/ckb-sdk-js/issues/365)


### BREAKING CHANGES

* **rpc:** use bigint instead of number in signatures of rpc methods