### PR TITLE
Generate Raw Transaction is now generic

### DIFF
--- a/packages/ckb-sdk-core/examples/sendTransaction.js
+++ b/packages/ckb-sdk-core/examples/sendTransaction.js
@@ -3,8 +3,8 @@ const Core = require('../lib').default
 
 const bootstrap = async () => {
   const nodeUrl = process.env.NODE_URL || 'http://localhost:8114' // example node url
-  const privateKey = process.env.PRIV_KEY || '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' // example private key
-  const blockAssemblerCodeHash = '0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2' // transcribe the block_assembler.code_hash in the ckb.toml from the ckb project
+  const privateKey = process.env.PRIV_KEY || '0xd00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc' // example private key
+  const blockAssemblerCodeHash = "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8" // transcribe the block_assembler.code_hash in the ckb.toml from the ckb project
 
   const core = new Core(nodeUrl) // instantiate the JS SDK with provided node url
 
@@ -64,6 +64,7 @@ const bootstrap = async () => {
     lockHash
   })
 
+
   /**
    * to see the unspent cells
    */
@@ -72,18 +73,26 @@ const bootstrap = async () => {
   /**
    * send transaction
    */
-  const toAddress = core.utils.privateKeyToAddress("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", {
-    prefix: 'ckt'
-  })
 
+
+  const recipientPubKey = core.utils.privateKeyToPublicKey("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+  const recipientPubKeyHash = `0x${core.utils.blake160(recipientPubKey, 'hex')}`
   const rawTransaction = await core.generateRawTransaction({
     fromAddress: addresses.testnetAddress,
-    toAddress,
-    capacity: 600000000000,
     fee: 100000,
     safeMode: true,
     cells: unspentCells,
     deps: core.config.secp256k1Dep,
+    outputs: [{
+      capacity: 600000000000,
+      lock: {
+        hashType: "type",
+        codeHash: blockAssemblerCodeHash,
+        args: recipientPubKeyHash
+      },
+      type: null
+    }],
+    outputsData: ["0x"]
   })
 
   rawTransaction.witnesses = rawTransaction.inputs.map(() => '0x')

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -174,26 +174,22 @@ class Core {
 
   public generateRawTransaction = async ({
     fromAddress,
-    toAddress,
-    capacity,
     fee,
     safeMode = true,
     cells = [],
     deps = this.config.secp256k1Dep!,
+    outputs,
+    outputsData,
   }: {
     fromAddress: string
-    toAddress: string
-    capacity: string | bigint
     fee: string | bigint
     safeMode: boolean
     cells: CachedCell[]
     deps: DepCellInfo
+    outputs: Output[]
+    outputsData: string[]
   }) => {
-    const [fromPublicKeyHash, toPublicKeyHash] = [fromAddress, toAddress].map((addr: string) => {
-      const addressPayload = this.utils.parseAddress(addr, 'hex')
-      return `0x${addressPayload.slice(hrpSize)}`
-    })
-
+    const fromPublicKeyHash = `0x${this.utils.parseAddress(fromAddress, 'hex').slice(hrpSize)}`
     let availableCells = cells
     if (!availableCells.length && deps) {
       const lockHash = this.utils.scriptToHash({
@@ -212,12 +208,12 @@ class Core {
 
     return generateRawTransaction({
       fromPublicKeyHash,
-      toPublicKeyHash,
-      capacity,
       fee,
       safeMode,
       cells: availableCells,
       deps,
+      outputs,
+      outputsData,
     })
   }
 }

--- a/packages/ckb-sdk-core/types/global.d.ts
+++ b/packages/ckb-sdk-core/types/global.d.ts
@@ -16,3 +16,9 @@ interface TransactionBuilderInitParams {
   headerDeps?: string[]
   witnesses?: string[]
 }
+
+interface Output {
+  capacity: integer | string
+  lock: CKBComponents.Script
+  type?: CKBComponents.Script | null
+}


### PR DESCRIPTION
This refers to issue 380. Changes were made so generate raw transaction is not confined to sendCapacity use cases when there are many other use cases. 

If we want to offer sdk method for making a transfer, that can be built on top of generate raw transaction. 

Send capacity example was also updated to reflect changes to generate raw transaction. The private key and block assembler are changed to use one of the "cell wallets" created on genesis while in dev mode.

