### PR TITLE
add the missing 's' to 'CKBComponent.Script'

### DIFF
--- a/packages/ckb-sdk-core/types/global.d.ts
+++ b/packages/ckb-sdk-core/types/global.d.ts
@@ -8,7 +8,7 @@ interface DepCellInfo {
 interface CachedCell extends CKBComponents.CellIncludingOutPoint {
   status: string
   dataHash: string
-  type: CKBComponents.Script | null
+  type?: CKBComponents.Script | null
 }
 
 type StructuredWitness = CKBComponents.WitnessArgs | CKBComponents.Witness

--- a/packages/ckb-sdk-core/types/global.d.ts
+++ b/packages/ckb-sdk-core/types/global.d.ts
@@ -8,7 +8,7 @@ interface DepCellInfo {
 interface CachedCell extends CKBComponents.CellIncludingOutPoint {
   status: string
   dataHash: string
-  type: CKBComponent.Script | null
+  type: CKBComponents.Script | null
 }
 
 type StructuredWitness = CKBComponents.WitnessArgs | CKBComponents.Witness


### PR DESCRIPTION
fixed a misstyping from 'CKBComponent' to 'CKBComponents'
fixed type mismatch between CachedCell.type and CellOutput.type