### PR TITLE
refactor(utils): refine ECPair

### DIFF
--- a/packages/ckb-sdk-utils/__tests__/ecpair/ecpare.fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/ecpair/ecpare.fixtures.json
@@ -62,6 +62,13 @@
       "privateKey": "0xe79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3",
       "compressed": true,
       "publicKey": "0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01"
+    },
+    "privateKeyHasInvalidLength": {
+      "privateKey": "0xf70eea3041c793746f07d47f28a62d6555041b9edc74501a75ffbf47c55fc9",
+      "exception": "Private key has invalid length"
+    },
+    "leadingZeroShouldBeRemained": {
+      "privateKey": "0x00f70eea3041c793746f07d47f28a62d6555041b9edc74501a75ffbf47c55fc9"
     }
   }
 }

--- a/packages/ckb-sdk-utils/__tests__/ecpair/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/ecpair/index.test.js
@@ -24,7 +24,7 @@ describe('ECPair', () => {
   it('new ecpair with empty options, default compressed should be true', () => {
     const fixture = instantiateFixtures.withEmptyOption
 
-    const ecpair = new ECPair(hexToBytes(fixture.privateKey), {})
+    const ecpair = new ECPair(fixture.privateKey, {})
     expect(ecpair.compressed).toBe(fixture.compressed)
     expect(ecpair.privateKey).toEqual(fixture.privateKey)
     expect(ecpair.publicKey).toBe(fixture.publicKey)
@@ -33,7 +33,7 @@ describe('ECPair', () => {
   it('new ecpair with default options which should be { compressed: true }', () => {
     const fixture = instantiateFixtures.withDefaultOption
 
-    const ecpair = new ECPair(hexToBytes(fixture.privateKey))
+    const ecpair = new ECPair(fixture.privateKey)
     expect(ecpair.compressed).toBe(fixture.compressed)
     expect(ecpair.privateKey).toEqual(fixture.privateKey)
     expect(ecpair.publicKey).toBe(fixture.publicKey)
@@ -46,6 +46,18 @@ describe('ECPair', () => {
   it('Instantiate with a private key without 0x should throw an error', () => {
     const privateKey = 'e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3'
     expect(() => new ECPair(privateKey, {})).toThrow(new HexStringShouldStartWith0x(privateKey))
+  })
+
+  it('shoule throw an error if private key has invalid length', () => {
+    const fixture = instantiateFixtures.privateKeyHasInvalidLength
+    expect(() => new ECPair(fixture.privateKey)).toThrow(new Error(fixture.exception))
+    expect(() => new ECPair(hexToBytes(fixture.privateKey), 'hex')).toThrow(fixture.exception)
+  })
+
+  it('leading 0 of private key should be remained', () => {
+    const fixture = instantiateFixtures.leadingZeroShouldBeRemained
+    const key = new ECPair(fixture.privateKey)
+    expect(key.privateKey).toBe(fixture.privateKey)
   })
 
   it('sign and verify message', () => {

--- a/packages/ckb-sdk-utils/src/ecpair.ts
+++ b/packages/ckb-sdk-utils/src/ecpair.ts
@@ -18,18 +18,28 @@ class ECPair {
     sk: Uint8Array | string,
     { compressed = true }: Options = {
       compressed: true,
-    }
+    },
   ) {
     if (sk === undefined) throw new ArgumentRequired('Private key')
+
     if (typeof sk === 'string' && !sk.startsWith('0x')) {
       throw new HexStringShouldStartWith0x(sk)
     }
+
+    if (typeof sk === 'string' && sk.length !== 66) {
+      throw new Error('Private key has invalid length')
+    }
+
+    if (typeof sk === 'object' && sk.byteLength !== 32) {
+      throw new Error('Private key has invalid length')
+    }
+
     this.key = ec.keyFromPrivate(typeof sk === 'string' ? sk.replace(/^0x/, '') : sk)
     this.compressed = compressed
   }
 
   get privateKey() {
-    return `0x${this.key.getPrivate('hex')}`
+    return `0x${this.key.getPrivate('hex').padStart(64, '0')}`
   }
 
   get publicKey() {


### PR DESCRIPTION
1. check the length of provided private key. 2. remain leading 0 of private key.