### PR TITLE
[ᚬmaster] Rc/v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)
+
+**Note:** Version bump only for package ckb-sdk-js
+
+
+
+
+
 ## [0.26.4](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.3...v0.26.4) (2020-01-02)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.26.4"
+  "version": "0.27.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-core
+
+
+
+
+
 ## [0.26.4](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.3...v0.26.4) (2020-01-02)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-core

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -35,5 +35,5 @@
     "@nervosnetwork/ckb-sdk-utils": "0.27.0",
     "@nervosnetwork/ckb-types": "0.27.0"
   },
-  "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"
+  "gitHead": "452e737d8602410ecccc132143c6ee641c61a000"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.26.4",
+  "version": "0.27.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,9 +31,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.26.4",
-    "@nervosnetwork/ckb-sdk-utils": "0.26.4",
-    "@nervosnetwork/ckb-types": "0.26.4"
+    "@nervosnetwork/ckb-sdk-rpc": "0.27.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.27.0",
+    "@nervosnetwork/ckb-types": "0.27.0"
   },
   "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"
 }

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc
+
+
+
+
+
 ## [0.26.4](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.3...v0.26.4) (2020-01-02)
 
 

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -40,5 +40,5 @@
     "@nervosnetwork/ckb-types": "0.27.0",
     "dotenv": "8.1.0"
   },
-  "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"
+  "gitHead": "452e737d8602410ecccc132143c6ee641c61a000"
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.26.4",
+  "version": "0.27.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,11 +33,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.26.4",
+    "@nervosnetwork/ckb-sdk-utils": "0.27.0",
     "axios": "0.19.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.26.4",
+    "@nervosnetwork/ckb-types": "0.27.0",
     "dotenv": "8.1.0"
   },
   "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 ## [0.26.4](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.3...v0.26.4) (2020-01-02)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.26.4",
+  "version": "0.27.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.26.4",
+    "@nervosnetwork/ckb-types": "0.27.0",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.1",
     "jsbi": "3.1.1"

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -41,5 +41,5 @@
     "@types/elliptic": "6.4.8",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"
+  "gitHead": "452e737d8602410ecccc132143c6ee641c61a000"
 }

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 ## [0.26.4](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.3...v0.26.4) (2020-01-02)
 
 

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "9f485f3db58382495fbf9cbadc0f9fd089872850"
+  "gitHead": "452e737d8602410ecccc132143c6ee641c61a000"
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.26.4",
+  "version": "0.27.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",


### PR DESCRIPTION
# [0.27.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.26.4...v0.27.0) (2020-01-11)

**Note:** Version bump only for package ckb-sdk-js