### PR TITLE
[ᚬmaster] rc/v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)
+
+
+### Features
+
+* **rpc:** update the action of outputs validator when it is null ([4932c47](https://github.com/nervosnetwork/ckb-sdk-js/commit/4932c479141b6d7a109705c389290b66d67c83a2))
+
+
+### BREAKING CHANGES
+
+* **rpc:** null outputs validator is equivalent to the passthrough one
+
+
+
+
+
 # [0.28.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.27.1...v0.28.0) (2020-02-07)
 
 **Note:** Version bump only for package ckb-sdk-js

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.28.0"
+  "version": "0.29.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-core
+
+
+
+
+
 # [0.28.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.27.1...v0.28.0) (2020-02-07)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-core

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,9 +31,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.28.0",
-    "@nervosnetwork/ckb-sdk-utils": "0.28.0",
-    "@nervosnetwork/ckb-types": "0.28.0"
+    "@nervosnetwork/ckb-sdk-rpc": "0.29.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.29.0",
+    "@nervosnetwork/ckb-types": "0.29.0"
   },
   "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -35,5 +35,5 @@
     "@nervosnetwork/ckb-sdk-utils": "0.29.0",
     "@nervosnetwork/ckb-types": "0.29.0"
   },
-  "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"
+  "gitHead": "0907e4ead0d2ff70dab46fd9ba637d9ee9f02a15"
 }

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)
+
+
+### Features
+
+* **rpc:** update the action of outputs validator when it is null ([4932c47](https://github.com/nervosnetwork/ckb-sdk-js/commit/4932c479141b6d7a109705c389290b66d67c83a2))
+
+
+### BREAKING CHANGES
+
+* **rpc:** null outputs validator is equivalent to the passthrough one
+
+
+
+
+
 # [0.28.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.27.1...v0.28.0) (2020-02-07)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,11 +33,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.28.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.29.0",
     "axios": "0.19.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.28.0",
+    "@nervosnetwork/ckb-types": "0.29.0",
     "dotenv": "8.1.0"
   },
   "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -40,5 +40,5 @@
     "@nervosnetwork/ckb-types": "0.29.0",
     "dotenv": "8.1.0"
   },
-  "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"
+  "gitHead": "0907e4ead0d2ff70dab46fd9ba637d9ee9f02a15"
 }

--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -275,12 +275,12 @@ export class DefaultRPC {
    *                                  detailed info could be found in ckb-types
    * @param {string} [outputsValidator] - Validates the transaction outputs before entering the tx-pool,
    *                                  an optional string parameter (enum: default | passthrough ),
-   *                                  null means using default validator, passthrough means skipping outputs validation
+   *                                  null and passthrough mean skipping outputs validation
    * @return {Promise<string>} transaction hash
    */
   public sendTransaction!: (
     tx: CKBComponents.RawTransaction,
-    outputsValidator: CKBComponents.OutputsValidator,
+    outputsValidator?: CKBComponents.OutputsValidator,
   ) => Promise<CKBComponents.Hash>
 
   /**

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 # [0.28.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.27.1...v0.28.0) (2020-02-07)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -41,5 +41,5 @@
     "@types/elliptic": "6.4.8",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"
+  "gitHead": "0907e4ead0d2ff70dab46fd9ba637d9ee9f02a15"
 }

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.28.0",
+    "@nervosnetwork/ckb-types": "0.29.0",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.2",
     "jsbi": "3.1.1"

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 # [0.28.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.27.1...v0.28.0) (2020-02-07)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-types

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "c41b6eff8466ba80c8db5da36fc1fc531bccca39"
+  "gitHead": "0907e4ead0d2ff70dab46fd9ba637d9ee9f02a15"
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",


### PR DESCRIPTION
# [0.29.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.0) (2020-02-28)


### Features

* **rpc:** update the action of outputs validator when it is null ([4932c47](https://github.com/nervosnetwork/ckb-sdk-js/commit/4932c479141b6d7a109705c389290b66d67c83a2))


### BREAKING CHANGES

* **rpc:** null outputs validator is equivalent to the passthrough one