### PR TITLE
[ᚬmaster] Rc/v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)
+
+
+### Features
+
+* **rpc:** add a new field in the tx pool info ([c1cbac9](https://github.com/nervosnetwork/ckb-sdk-js/commit/c1cbac9aeb1799f611543696f7ee9b717cfb237d))
+* **rpc:** add the new RPC getBlockEconomicState ([0c9e248](https://github.com/nervosnetwork/ckb-sdk-js/commit/0c9e248d810dcbe83953f262385b4a8efb5d4f84))
+
+
+
+
+
 ## [0.29.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.1) (2020-02-28)
 
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ After that you can use the `ckb` object to generate addresses, send requests, et
 
 ## Default RPC
 
-Please see [Default RPC](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/defaultRPC.ts#L182)
+Please see [Default RPC](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/defaultRPC.ts#L188)
 
 ## Persistent Connection
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.29.1"
+  "version": "0.30.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-core
+
+
+
+
+
 ## [0.29.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.1) (2020-02-28)
 
 

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,9 +31,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.29.1",
-    "@nervosnetwork/ckb-sdk-utils": "0.29.1",
-    "@nervosnetwork/ckb-types": "0.29.1"
+    "@nervosnetwork/ckb-sdk-rpc": "0.30.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.30.0",
+    "@nervosnetwork/ckb-types": "0.30.0"
   },
   "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -35,5 +35,5 @@
     "@nervosnetwork/ckb-sdk-utils": "0.30.0",
     "@nervosnetwork/ckb-types": "0.30.0"
   },
-  "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"
+  "gitHead": "493655c726e4e4918dfe4ac7ef5d1fec1a539117"
 }

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)
+
+
+### Features
+
+* **rpc:** add a new field in the tx pool info ([c1cbac9](https://github.com/nervosnetwork/ckb-sdk-js/commit/c1cbac9aeb1799f611543696f7ee9b717cfb237d))
+* **rpc:** add the new RPC getBlockEconomicState ([0c9e248](https://github.com/nervosnetwork/ckb-sdk-js/commit/0c9e248d810dcbe83953f262385b4a8efb5d4f84))
+
+
+
+
+
 ## [0.29.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.1) (2020-02-28)
 
 

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
@@ -38,8 +38,8 @@ describe('ckb-rpc settings and helpers', () => {
     expect(rpc.node.httpsAgent).toBeDefined()
   })
 
-  it('has 30 default rpc', () => {
-    expect(rpc.methods.length).toBe(30)
+  it('has 31 default rpc', () => {
+    expect(rpc.methods.length).toBe(31)
   })
 
   it('set node url to http://test.localhost:8114', () => {

--- a/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
@@ -1307,5 +1307,41 @@
         "cellsCount": "0x3f5"
       }
     }
+  ],
+  "toBlockEconomicState": [
+    {
+      "result": null,
+      "expected": null
+    },
+    {
+      "result": {
+        "finalized_at": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "issuance": {
+          "primary": "0x18ce922bca",
+          "secondary": "0x7f02ec655"
+        },
+        "miner_reward": {
+          "committed": "0x0",
+          "primary": "0x18ce922bca",
+          "proposal": "0x0",
+          "secondary": "0x17b93605"
+        },
+        "txs_fee": "0x0"
+      },
+      "expected": {
+        "finalizedAt": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "issuance": {
+          "primary": "0x18ce922bca",
+          "secondary": "0x7f02ec655"
+        },
+        "minerReward": {
+          "committed": "0x0",
+          "primary": "0x18ce922bca",
+          "proposal": "0x0",
+          "secondary": "0x17b93605"
+        },
+        "txsFee": "0x0"
+      }
+    }
   ]
 }

--- a/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
@@ -538,20 +538,22 @@
     },
     {
       "result": {
-        "orphan": "33",
-        "pending": "34",
-        "proposed": "22",
-        "last_txs_updated_at": "1555507787683",
-        "total_tx_cycles": "12",
-        "total_tx_size": "156"
+        "orphan": "0x33",
+        "pending": "0x34",
+        "proposed": "0x22",
+        "last_txs_updated_at": "0x0",
+        "total_tx_cycles": "0x12",
+        "total_tx_size": "0x156",
+        "min_fee_rate": "0x3e8"
       },
       "expected": {
-        "orphan": "33",
-        "pending": "34",
-        "proposed": "22",
-        "lastTxsUpdatedAt": "1555507787683",
-        "totalTxCycles": "12",
-        "totalTxSize": "156"
+        "orphan": "0x33",
+        "pending": "0x34",
+        "proposed": "0x22",
+        "lastTxsUpdatedAt": "0x0",
+        "totalTxCycles": "0x12",
+        "totalTxSize": "0x156",
+        "minFeeRate": "0x3e8"
       }
     }
   ],

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -40,5 +40,5 @@
     "@nervosnetwork/ckb-types": "0.30.0",
     "dotenv": "8.1.0"
   },
-  "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"
+  "gitHead": "493655c726e4e4918dfe4ac7ef5d1fec1a539117"
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,11 +33,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.29.1",
+    "@nervosnetwork/ckb-sdk-utils": "0.30.0",
     "axios": "0.19.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.29.1",
+    "@nervosnetwork/ckb-types": "0.30.0",
     "dotenv": "8.1.0"
   },
   "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"

--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -177,6 +177,12 @@ const defaultRPC: CKBComponents.Method[] = [
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toCapacityByLockHash,
   },
+  {
+    name: 'getBlockEconomicState',
+    method: 'get_block_economic_state',
+    paramsFormatters: [paramsFmts.toHash],
+    resultFormatters: resultFmts.toBlockEconomicState,
+  },
 ]
 
 export class DefaultRPC {
@@ -489,6 +495,15 @@ export class DefaultRPC {
   ) => Promise<string>
 
   public getCapacityByLockHash!: (lockHash: CKBComponents.Hash) => Promise<CKBComponents.CapacityByLockHash>
+
+  /**
+   * @method getBlockEconomicState
+   * @memberof DefaultRPC
+   * @description
+   * @param {string} blockHash
+   * @returns {Promise<BlockEconomicState>}
+   */
+  public getBlockEconomicState!: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockEconomicState>
 }
 
 export default DefaultRPC

--- a/packages/ckb-sdk-rpc/src/resultFormatter.ts
+++ b/packages/ckb-sdk-rpc/src/resultFormatter.ts
@@ -317,6 +317,18 @@ const formatter = {
       ...rest,
     }
   },
+  toBlockEconomicState: (blockEconomicState: RPC.BlockEconomicState): CKBComponents.BlockEconomicState => {
+    if (!blockEconomicState) {
+      return blockEconomicState
+    }
+    const { finalized_at: finalizedAt, miner_reward: minerReward, txs_fee: txsFee, ...rest } = blockEconomicState
+    return {
+      finalizedAt,
+      minerReward,
+      txsFee,
+      ...rest,
+    }
+  },
 }
 
 export default formatter

--- a/packages/ckb-sdk-rpc/src/resultFormatter.ts
+++ b/packages/ckb-sdk-rpc/src/resultFormatter.ts
@@ -135,12 +135,14 @@ const formatter = {
       last_txs_updated_at: lastTxsUpdatedAt,
       total_tx_cycles: totalTxCycles,
       total_tx_size: totalTxSize,
+      min_fee_rate: minFeeRate,
       ...rest
     } = info
     return {
       lastTxsUpdatedAt,
       totalTxCycles,
       totalTxSize,
+      minFeeRate,
       ...rest,
     }
   },

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -188,6 +188,7 @@ declare module RPC {
     last_txs_updated_at: Timestamp
     total_tx_cycles: Cycles
     total_tx_size: Size
+    min_fee_rate: string
   }
 
   export interface Epoch {

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -231,5 +231,20 @@ declare module RPC {
     capacity: Capacity
     cells_count: Number
   }
+
+  export interface BlockEconomicState {
+    finalized_at: string
+    issuance: {
+      primary: string
+      secondary: string
+    }
+    miner_reward: {
+      committed: string
+      primary: string
+      proposal: string
+      secondary: string
+    }
+    txs_fee: string
+  }
 }
 /* eslint-enable camelcase */

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 ## [0.29.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.1) (2020-02-28)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -41,5 +41,5 @@
     "@types/elliptic": "6.4.8",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"
+  "gitHead": "493655c726e4e4918dfe4ac7ef5d1fec1a539117"
 }

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.29.1",
+    "@nervosnetwork/ckb-types": "0.30.0",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.2",
     "jsbi": "3.1.1"

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)
+
+
+### Features
+
+* **rpc:** add a new field in the tx pool info ([c1cbac9](https://github.com/nervosnetwork/ckb-sdk-js/commit/c1cbac9aeb1799f611543696f7ee9b717cfb237d))
+* **rpc:** add the new RPC getBlockEconomicState ([0c9e248](https://github.com/nervosnetwork/ckb-sdk-js/commit/0c9e248d810dcbe83953f262385b4a8efb5d4f84))
+
+
+
+
+
 ## [0.29.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.28.0...v0.29.1) (2020-02-28)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-types

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -326,6 +326,7 @@ declare namespace CKBComponents {
     lastTxsUpdatedAt: Timestamp
     totalTxCycles: Cycles
     totalTxSize: Size
+    minFeeRate: string
   }
 
   export enum CapacityUnit {

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -391,4 +391,19 @@ declare namespace CKBComponents {
     capacity: Capacity
     cellsCount: Number
   }
+
+  export interface BlockEconomicState {
+    finalizedAt: string
+    issuance: {
+      primary: string
+      secondary: string
+    }
+    minerReward: {
+      committed: string
+      primary: string
+      proposal: string
+      secondary: string
+    }
+    txsFee: string
+  }
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "dacec65239c3683f4ea0e5b1946f9ec74d275500"
+  "gitHead": "493655c726e4e4918dfe4ac7ef5d1fec1a539117"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,9 +1432,9 @@ acorn-walk@^6.0.1:
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
 acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.0.1:
   version "6.4.0"


### PR DESCRIPTION
# [0.30.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.29.1...v0.30.0) (2020-03-23)


### Features

* **rpc:** add a new field in the tx pool info ([c1cbac9](https://github.com/nervosnetwork/ckb-sdk-js/commit/c1cbac9aeb1799f611543696f7ee9b717cfb237d))
* **rpc:** add the new RPC getBlockEconomicState ([0c9e248](https://github.com/nervosnetwork/ckb-sdk-js/commit/0c9e248d810dcbe83953f262385b4a8efb5d4f84))