### PR TITLE
[ᚬrc/v0.30.0] feat(rpc): add the new RPC getBlockEconomicState

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ After that you can use the `ckb` object to generate addresses, send requests, et
 
 ## Default RPC
 
-Please see [Default RPC](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/defaultRPC.ts#L182)
+Please see [Default RPC](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/defaultRPC.ts#L188)
 
 ## Persistent Connection
 

--- a/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
@@ -1307,5 +1307,41 @@
         "cellsCount": "0x3f5"
       }
     }
+  ],
+  "toBlockEconomicState": [
+    {
+      "result": null,
+      "expected": null
+    },
+    {
+      "result": {
+        "finalized_at": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "issuance": {
+          "primary": "0x18ce922bca",
+          "secondary": "0x7f02ec655"
+        },
+        "miner_reward": {
+          "committed": "0x0",
+          "primary": "0x18ce922bca",
+          "proposal": "0x0",
+          "secondary": "0x17b93605"
+        },
+        "txs_fee": "0x0"
+      },
+      "expected": {
+        "finalizedAt": "0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40",
+        "issuance": {
+          "primary": "0x18ce922bca",
+          "secondary": "0x7f02ec655"
+        },
+        "minerReward": {
+          "committed": "0x0",
+          "primary": "0x18ce922bca",
+          "proposal": "0x0",
+          "secondary": "0x17b93605"
+        },
+        "txsFee": "0x0"
+      }
+    }
   ]
 }

--- a/packages/ckb-sdk-rpc/src/defaultRPC.ts
+++ b/packages/ckb-sdk-rpc/src/defaultRPC.ts
@@ -177,6 +177,12 @@ const defaultRPC: CKBComponents.Method[] = [
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toCapacityByLockHash,
   },
+  {
+    name: 'getBlockEconomicState',
+    method: 'get_block_economic_state',
+    paramsFormatters: [paramsFmts.toHash],
+    resultFormatters: resultFmts.toBlockEconomicState,
+  },
 ]
 
 export class DefaultRPC {
@@ -489,6 +495,15 @@ export class DefaultRPC {
   ) => Promise<string>
 
   public getCapacityByLockHash!: (lockHash: CKBComponents.Hash) => Promise<CKBComponents.CapacityByLockHash>
+
+  /**
+   * @method getBlockEconomicState
+   * @memberof DefaultRPC
+   * @description
+   * @param {string} blockHash
+   * @returns {Promise<BlockEconomicState>}
+   */
+  public getBlockEconomicState!: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockEconomicState>
 }
 
 export default DefaultRPC

--- a/packages/ckb-sdk-rpc/src/resultFormatter.ts
+++ b/packages/ckb-sdk-rpc/src/resultFormatter.ts
@@ -317,6 +317,18 @@ const formatter = {
       ...rest,
     }
   },
+  toBlockEconomicState: (blockEconomicState: RPC.BlockEconomicState): CKBComponents.BlockEconomicState => {
+    if (!blockEconomicState) {
+      return blockEconomicState
+    }
+    const { finalized_at: finalizedAt, miner_reward: minerReward, txs_fee: txsFee, ...rest } = blockEconomicState
+    return {
+      finalizedAt,
+      minerReward,
+      txsFee,
+      ...rest,
+    }
+  },
 }
 
 export default formatter

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -231,5 +231,20 @@ declare module RPC {
     capacity: Capacity
     cells_count: Number
   }
+
+  export interface BlockEconomicState {
+    finalized_at: string
+    issuance: {
+      primary: string
+      secondary: string
+    }
+    miner_reward: {
+      committed: string
+      primary: string
+      proposal: string
+      secondary: string
+    }
+    txs_fee: string
+  }
 }
 /* eslint-enable camelcase */

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -391,4 +391,19 @@ declare namespace CKBComponents {
     capacity: Capacity
     cellsCount: Number
   }
+
+  export interface BlockEconomicState {
+    finalizedAt: string
+    issuance: {
+      primary: string
+      secondary: string
+    }
+    minerReward: {
+      committed: string
+      primary: string
+      proposal: string
+      secondary: string
+    }
+    txsFee: string
+  }
 }


### PR DESCRIPTION
The new RPC returns the increased issuance, miner reward and total transaction fee of the specified block