### PR TITLE
feat: use signature provider in signWitnesses & signWitnessGroup

### DIFF
--- a/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
@@ -109,7 +109,7 @@
         "outputType": ""
       }
     ],
-    "exception": "Private key is required"
+    "exception": "Signature provider is required"
   },
   "lack of transaction hash should throw an error": {
     "privateKey": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -180,7 +180,7 @@
         "outputType": ""
       }
     ],
-    "exception": "The private key to sign lockhash 0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b is not found"
+    "exception": "The signature provider to sign lockhash 0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b is not found"
   },
   "witnesses cannot be empty": {
     "privateKey": "0xdcec27d0d975b0378471183a03f7071dea8532aaf968be796719ecd20af6988f",

--- a/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
@@ -95,6 +95,78 @@
       }
     ]
   },
+  "multi groups using signature provider": {
+    "signatureProviders": [
+      [
+        "0xc6a5303d5fb970e2bd4e81e984c0a52b7bc5b42ab2b777583ea2cb74868f5708",
+        "0xdcec27d0d975b0378471183a03f7071dea8532aaf968be796719ecd20af6988f"
+      ],
+      [
+        "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      ]
+    ],
+    "inputCells": [
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xedb5c73f2a4ad8df23467c9f3446f5851b5e33da"
+        }
+      },
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+        }
+      },
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xedb5c73f2a4ad8df23467c9f3446f5851b5e33da"
+        }
+      }
+    ],
+    "transactionHash": "0x4a4bcfef1b7448e27edf533df2f1de9f56be05eba645fb83f42d55816797ad2a",
+    "witnesses": [
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      }
+    ],
+    "expected": [
+      "0x5500000010000000550000005500000041000000d59792eee1e67747d25a36304bf155665a9b552ecda2d84390ba6acfc422dc3f4b599165078ed98c4e930dec79866b50984f3458c5010faefce6574b9659329501",
+      "0x550000001000000055000000550000004100000091af5eeb1632565dc4a9fb1c6e08d1f1c7da96e10ee00595a2db208f1d15faca03332a1f0f7a0f8522f6e112bb8dde4ed0015d1683b998744a0d8644f0dfd0f800",
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      }
+    ]
+  },
   "lack of private keys should throw an error": {
     "transactionHash": "0x4a4bcfef1b7448e27edf533df2f1de9f56be05eba645fb83f42d55816797ad2a",
     "witnesses": [

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -206,7 +206,7 @@ class CKB {
 
   public signTransaction = (
     key: Key | Map<LockHash, Key>
-  ) => (
+  ) => async (
     transaction: CKBComponents.RawTransactionToSign,
     cells: CachedCell[]
   ) => {
@@ -229,7 +229,7 @@ class CKB {
       return cell
     }) : undefined
 
-    const signedWitnesses = this.signWitnesses(key)({
+    const signedWitnesses = await this.signWitnesses(key)({
       transactionHash,
       witnesses: transaction.witnesses,
       inputCells,

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -206,7 +206,7 @@ class CKB {
 
   public signTransaction = (
     key: Key | Map<LockHash, Key>
-  ) => async (
+  ) => (
     transaction: CKBComponents.RawTransactionToSign,
     cells: CachedCell[]
   ) => {
@@ -229,7 +229,7 @@ class CKB {
       return cell
     }) : undefined
 
-    const signedWitnesses = await this.signWitnesses(key)({
+    const signedWitnesses = this.signWitnesses(key)({
       transactionHash,
       witnesses: transaction.witnesses,
       inputCells,

--- a/packages/ckb-sdk-core/src/signWitnessGroup.ts
+++ b/packages/ckb-sdk-core/src/signWitnessGroup.ts
@@ -1,10 +1,10 @@
 import { blake2b, hexToBytes, PERSONAL, toHexInLittleEndian, serializeWitnessArgs } from '@nervosnetwork/ckb-sdk-utils'
 import ECPair from '@nervosnetwork/ckb-sdk-utils/lib/ecpair'
 
-type Key = string
+type SignatureProvider = string | ((message: string | Uint8Array) => Promise<string>)
 type TransactionHash = string
 
-const signWitnessGroup = (sk: Key, transactionHash: TransactionHash, witnessGroup: StructuredWitness[]) => {
+const signWitnessGroup = async (sk: SignatureProvider, transactionHash: TransactionHash, witnessGroup: StructuredWitness[]) => {
   if (!witnessGroup.length) {
     throw new Error('WitnessGroup cannot be empty')
   }
@@ -32,8 +32,12 @@ const signWitnessGroup = (sk: Key, transactionHash: TransactionHash, witnessGrou
   })
 
   const message = `0x${s.digest('hex')}`
-  const keyPair = new ECPair(sk)
-  emptyWitness.lock = keyPair.signRecoverable(message)
+  if (typeof sk === 'string') {
+    const keyPair = new ECPair(sk)
+    emptyWitness.lock = keyPair.signRecoverable(message)
+  } else {
+    emptyWitness.lock = await sk(message)
+  }
   return [serializeWitnessArgs(emptyWitness), ...witnessGroup.slice(1)]
 }
 

--- a/packages/ckb-sdk-core/src/signWitnessGroup.ts
+++ b/packages/ckb-sdk-core/src/signWitnessGroup.ts
@@ -1,10 +1,10 @@
 import { blake2b, hexToBytes, PERSONAL, toHexInLittleEndian, serializeWitnessArgs } from '@nervosnetwork/ckb-sdk-utils'
 import ECPair from '@nervosnetwork/ckb-sdk-utils/lib/ecpair'
 
-type SignatureProvider = string | ((message: string | Uint8Array) => Promise<string>)
+type SignatureProvider = string | ((message: string | Uint8Array) => string)
 type TransactionHash = string
 
-const signWitnessGroup = async (sk: SignatureProvider, transactionHash: TransactionHash, witnessGroup: StructuredWitness[]) => {
+const signWitnessGroup = (sk: SignatureProvider, transactionHash: TransactionHash, witnessGroup: StructuredWitness[]) => {
   if (!witnessGroup.length) {
     throw new Error('WitnessGroup cannot be empty')
   }
@@ -36,7 +36,7 @@ const signWitnessGroup = async (sk: SignatureProvider, transactionHash: Transact
     const keyPair = new ECPair(sk)
     emptyWitness.lock = keyPair.signRecoverable(message)
   } else {
-    emptyWitness.lock = await sk(message)
+    emptyWitness.lock = sk(message)
   }
   return [serializeWitnessArgs(emptyWitness), ...witnessGroup.slice(1)]
 }


### PR DESCRIPTION
A signature provider is a function that maps a message to signature. Use the signature provider to sign transactions can facilitate the integration of 3rd-party keypair manager when using the sdk.

To sign a transaction now, use
``` js
const signedWitnesses = signWitnesses(signatureProviderMap)({
  transactionHash,
  witnesses,
  inputCells,
  skipMissingKeys,
})
```

`signatureProviderMap` is a `Map<LockHash, SignatureProvider>` or a single `SignatureProvider`. A `SignatureProvider` can be either a plain string for a private key, or a function
``` js
function sigProvider (message: string) : string {
  // Possible code inside the 3rd-party keypair manager
  const privateKey = ThirdPartyKeypairManager.loadPrivateKey()
  const keyPair = new ECPair(privateKey)
  return keyPair.signRecoverable(message)
}
```

The `signWitnesses` function takes an extra option `skipMissingKeys` to skip signing for some witness groups if `signatureProvider` is not provided for their lock hashes. In some cases (e.g. anyone-can-pay) a witness is not required to unlock the cell.

## Possible further updates

The 3rd-party keypair manager may load private keys or sign messages asynchronously, so it's recommended to provide an async version for `signedWitnesses`. The `signTransaction` can also be updated to support using a signature provider, ideally with async support.

