### PR TITLE
Rc/v0.32.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,10 @@ module.exports = {
     "spaced-comment": ["error", "always", {
       "markers": ["/"]
     }],
-    "max-classes-per-file": [0]
+    "max-classes-per-file": [0],
+    "import/extensions": [2, {
+      "ts": "never"
+    }]
   },
   "globals": {
     "BigInt": "readonly"

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "useTabs": false,
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)
+
+
+### Features
+
+* **utils:** add convertors of uint-to-le ([16b6d80](https://github.com/nervosnetwork/ckb-sdk-js/commit/16b6d80f612a175aa6a72ad6324c89d5664fca94))
+* use signature provider in signWitnesses & signWitnessGroup ([#434](https://github.com/nervosnetwork/ckb-sdk-js/issues/434)) ([34d62bb](https://github.com/nervosnetwork/ckb-sdk-js/commit/34d62bb9c86b680e5887194131379c2a01b4f068))
+
+
+
+
+
 # [0.31.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.30.0...v0.31.0) (2020-04-21)
 
 **Note:** Version bump only for package ckb-sdk-js

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.31.0"
+  "version": "0.32.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)
+
+
+### Features
+
+* use signature provider in signWitnesses & signWitnessGroup ([#434](https://github.com/nervosnetwork/ckb-sdk-js/issues/434)) ([34d62bb](https://github.com/nervosnetwork/ckb-sdk-js/commit/34d62bb9c86b680e5887194131379c2a01b4f068))
+
+
+
+
+
 # [0.31.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.30.0...v0.31.0) (2020-04-21)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-core

--- a/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/signWitnesses/fixtures.json
@@ -95,6 +95,78 @@
       }
     ]
   },
+  "multi groups using signature provider": {
+    "signatureProviders": [
+      [
+        "0xc6a5303d5fb970e2bd4e81e984c0a52b7bc5b42ab2b777583ea2cb74868f5708",
+        "0xdcec27d0d975b0378471183a03f7071dea8532aaf968be796719ecd20af6988f"
+      ],
+      [
+        "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      ]
+    ],
+    "inputCells": [
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xedb5c73f2a4ad8df23467c9f3446f5851b5e33da"
+        }
+      },
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+        }
+      },
+      {
+        "lock": {
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type",
+          "args": "0xedb5c73f2a4ad8df23467c9f3446f5851b5e33da"
+        }
+      }
+    ],
+    "transactionHash": "0x4a4bcfef1b7448e27edf533df2f1de9f56be05eba645fb83f42d55816797ad2a",
+    "witnesses": [
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      }
+    ],
+    "expected": [
+      "0x5500000010000000550000005500000041000000d59792eee1e67747d25a36304bf155665a9b552ecda2d84390ba6acfc422dc3f4b599165078ed98c4e930dec79866b50984f3458c5010faefce6574b9659329501",
+      "0x550000001000000055000000550000004100000091af5eeb1632565dc4a9fb1c6e08d1f1c7da96e10ee00595a2db208f1d15faca03332a1f0f7a0f8522f6e112bb8dde4ed0015d1683b998744a0d8644f0dfd0f800",
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      },
+      {
+        "lock": "",
+        "inputType": "",
+        "outputType": ""
+      }
+    ]
+  },
   "lack of private keys should throw an error": {
     "transactionHash": "0x4a4bcfef1b7448e27edf533df2f1de9f56be05eba645fb83f42d55816797ad2a",
     "witnesses": [
@@ -109,7 +181,7 @@
         "outputType": ""
       }
     ],
-    "exception": "Private key is required"
+    "exception": "Signature provider is required"
   },
   "lack of transaction hash should throw an error": {
     "privateKey": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
@@ -180,7 +252,7 @@
         "outputType": ""
       }
     ],
-    "exception": "The private key to sign lockhash 0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b is not found"
+    "exception": "The signature provider to sign lockhash 0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b is not found"
   },
   "witnesses cannot be empty": {
     "privateKey": "0xdcec27d0d975b0378471183a03f7071dea8532aaf968be796719ecd20af6988f",

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,9 +31,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.31.0",
-    "@nervosnetwork/ckb-sdk-utils": "0.31.0",
-    "@nervosnetwork/ckb-types": "0.31.0"
+    "@nervosnetwork/ckb-sdk-rpc": "0.32.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.32.0",
+    "@nervosnetwork/ckb-types": "0.32.0"
   },
   "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -35,5 +35,5 @@
     "@nervosnetwork/ckb-sdk-utils": "0.32.0",
     "@nervosnetwork/ckb-types": "0.32.0"
   },
-  "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
+  "gitHead": "9895c230bf5782db4cc19bb51d42cb0ef62dcebc"
 }

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -1,7 +1,7 @@
 /// <reference types="../types/global" />
 
 import RPC from '@nervosnetwork/ckb-sdk-rpc'
-import { assertToBeHexString} from '@nervosnetwork/ckb-sdk-utils/lib/validators'
+import { assertToBeHexString } from '@nervosnetwork/ckb-sdk-utils/lib/validators'
 import { ArgumentRequired } from '@nervosnetwork/ckb-sdk-utils/lib/exceptions'
 import * as utils from '@nervosnetwork/ckb-sdk-utils'
 
@@ -9,7 +9,7 @@ import generateRawTransaction, { Cell, RawTransactionParamsBase } from './genera
 
 import loadCells from './loadCells'
 import signWitnesses, { isMap } from './signWitnesses'
-import {calculateLockEpochs} from './utils'
+import { calculateLockEpochs } from './utils'
 
 
 type Key = string
@@ -358,7 +358,7 @@ class CKB {
     if (tx.txStatus.status !== 'committed') throw new Error('Transaction is not committed yet')
 
     const depositBlockHeader = await this.rpc.getBlock(tx.txStatus.blockHash).then(b => b.header)
-    const encodedBlockNumber = this.utils.toHexInLittleEndian(depositBlockHeader.number, 8)
+    const encodedBlockNumber = this.utils.toUint64Le(depositBlockHeader.number)
 
     const fromAddress = this.utils.bech32Address(cellStatus.cell.output.lock.args)
 

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -11,7 +11,6 @@ import loadCells from './loadCells'
 import signWitnesses, { isMap } from './signWitnesses'
 import { calculateLockEpochs } from './utils'
 
-
 type Key = string
 type Address = string
 type LockHash = string
@@ -29,12 +28,11 @@ interface RawTransactionParams extends RawTransactionParamsBase {
 
 interface ComplexRawTransactoinParams extends RawTransactionParamsBase {
   fromAddresses: Address[]
-  receivePairs: {address: Address, capacity: Capacity}[],
+  receivePairs: { address: Address; capacity: Capacity }[]
   cells: Map<LockHash, CachedCell[]>
 }
 
 const hrpSize = 6
-
 
 class CKB {
   public cells: Map<LockHash, CachedCell[]> = new Map()

--- a/packages/ckb-sdk-core/src/loadCells.ts
+++ b/packages/ckb-sdk-core/src/loadCells.ts
@@ -7,19 +7,15 @@ const getMinBigInt = (x: JSBI, y: JSBI) => {
   return JSBI.greaterThan(x, y) ? y : x
 }
 
-const loadCells = async ({
-  lockHash,
-  start = '0x0',
-  end,
-  STEP = '0x64',
-  rpc,
-}: {
-  lockHash: string
+interface LoadCellsProps {
+  lockHash: CKBComponents.Hash
   start?: string | bigint
   end?: string | bigint
   STEP?: string | bigint
   rpc: RPC
-}) => {
+}
+
+const loadCells = async ({ lockHash, start = '0x0', end, STEP = '0x64', rpc }: LoadCellsProps) => {
   console.warn(`This method is only for demo, don't use it in production`)
   if (!lockHash) {
     throw new ArgumentRequired('lockHash')
@@ -56,7 +52,7 @@ const loadCells = async ({
         getMinBigInt(JSBI.add(from, JSBI.multiply(JSBI.BigInt(idx + 1), JSBI.BigInt(`${STEP}`))), to),
       ])
     : [[from, to]]
-  /* eslint-enabler indent */
+  /* eslint-enable indent */
 
   const cells: CachedCell[] = []
 

--- a/packages/ckb-sdk-core/src/signWitnessGroup.ts
+++ b/packages/ckb-sdk-core/src/signWitnessGroup.ts
@@ -4,7 +4,11 @@ import ECPair from '@nervosnetwork/ckb-sdk-utils/lib/ecpair'
 type SignatureProvider = string | ((message: string | Uint8Array) => string)
 type TransactionHash = string
 
-const signWitnessGroup = (sk: SignatureProvider, transactionHash: TransactionHash, witnessGroup: StructuredWitness[]) => {
+const signWitnessGroup = (
+  sk: SignatureProvider,
+  transactionHash: TransactionHash,
+  witnessGroup: StructuredWitness[],
+) => {
   if (!witnessGroup.length) {
     throw new Error('WitnessGroup cannot be empty')
   }

--- a/packages/ckb-sdk-core/src/signWitnessGroup.ts
+++ b/packages/ckb-sdk-core/src/signWitnessGroup.ts
@@ -1,4 +1,4 @@
-import { blake2b, hexToBytes, PERSONAL, toHexInLittleEndian, serializeWitnessArgs } from '@nervosnetwork/ckb-sdk-utils'
+import { blake2b, hexToBytes, PERSONAL, toUint64Le, serializeWitnessArgs } from '@nervosnetwork/ckb-sdk-utils'
 import ECPair from '@nervosnetwork/ckb-sdk-utils/lib/ecpair'
 
 type SignatureProvider = string | ((message: string | Uint8Array) => string)
@@ -22,12 +22,12 @@ const signWitnessGroup = (sk: SignatureProvider, transactionHash: TransactionHas
 
   const s = blake2b(32, null, null, PERSONAL)
   s.update(hexToBytes(transactionHash))
-  s.update(hexToBytes(toHexInLittleEndian(`0x${serialziedEmptyWitnessSize.toString(16)}`, 8)))
+  s.update(hexToBytes(toUint64Le(`0x${serialziedEmptyWitnessSize.toString(16)}`)))
   s.update(serializedEmptyWitnessBytes)
 
   witnessGroup.slice(1).forEach(w => {
     const bytes = hexToBytes(typeof w === 'string' ? w : serializeWitnessArgs(w))
-    s.update(hexToBytes(toHexInLittleEndian(`0x${bytes.length.toString(16)}`, 8)))
+    s.update(hexToBytes(toUint64Le(`0x${bytes.length.toString(16)}`)))
     s.update(bytes)
   })
 

--- a/packages/ckb-sdk-core/src/signWitnesses.ts
+++ b/packages/ckb-sdk-core/src/signWitnesses.ts
@@ -2,22 +2,27 @@ import { ArgumentRequired } from '@nervosnetwork/ckb-sdk-utils/lib/exceptions'
 import signWitnessGroup from './signWitnessGroup'
 import groupScripts from './groupScripts'
 
-type Key = string
+type SignatureProvider = string | ((message: string | Uint8Array) => string)
 type LockHash = string
 type TransactionHash = string
 type CachedLock = Pick<CachedCell, 'lock'>
 
 export interface SignWitnesses {
-  (key: Key): (params: { transactionHash: TransactionHash; witnesses: StructuredWitness[] }) => StructuredWitness[]
-  (key: Map<LockHash, Key>): (params: {
+  (key: SignatureProvider): (params: {
+    transactionHash: TransactionHash
+    witnesses: StructuredWitness[]
+  }) => StructuredWitness[]
+  (key: Map<LockHash, SignatureProvider>): (params: {
     transactionHash: TransactionHash
     witnesses: StructuredWitness[]
     inputCells: CachedLock[]
+    skipMissingKeys: boolean
   }) => StructuredWitness[]
-  (key: Key | Map<LockHash, Key>): (params: {
+  (key: SignatureProvider | Map<LockHash, SignatureProvider>): (params: {
     transactionHash: TransactionHash
     witnesses: StructuredWitness[]
     inputCells?: CachedLock[]
+    skipMissingKeys?: boolean
   }) => StructuredWitness[]
 }
 
@@ -25,16 +30,18 @@ export const isMap = <K = any, V = any>(val: any): val is Map<K, V> => {
   return val.size !== undefined
 }
 
-const signWitnesses: SignWitnesses = (key: Key | Map<LockHash, Key>) => ({
+const signWitnesses: SignWitnesses = (key: SignatureProvider | Map<LockHash, SignatureProvider>) => ({
   transactionHash,
   witnesses = [],
   inputCells = [],
+  skipMissingKeys = false,
 }: {
   transactionHash: string
   witnesses: StructuredWitness[]
   inputCells: CachedLock[]
+  skipMissingKeys: boolean
 }) => {
-  if (!key) throw new ArgumentRequired('Private key')
+  if (!key) throw new ArgumentRequired('Signature provider')
   if (!transactionHash) throw new ArgumentRequired('Transaction hash')
   if (!witnesses.length) throw new Error('Witnesses is empty')
 
@@ -42,12 +49,18 @@ const signWitnesses: SignWitnesses = (key: Key | Map<LockHash, Key>) => ({
     const rawWitnesses = witnesses
     const restWitnesses = witnesses.slice(inputCells.length)
     const groupedScripts = groupScripts(inputCells)
+
     groupedScripts.forEach((indices, lockhash) => {
       const sk = key.get(lockhash)
       if (!sk) {
-        throw new Error(`The private key to sign lockhash ${lockhash} is not found`)
+        if (!skipMissingKeys) {
+          throw new Error(`The signature provider to sign lockhash ${lockhash} is not found`)
+        } else {
+          return
+        }
       }
-      const ws = [...indices.map(idx => witnesses[idx]), ...restWitnesses]
+
+      const ws = [...indices.map((idx) => witnesses[idx]), ...restWitnesses]
 
       const witnessIncludeSignature = signWitnessGroup(sk, transactionHash, ws)[0]
       rawWitnesses[indices[0]] = witnessIncludeSignature

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc
+
+
+
+
+
 # [0.31.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.30.0...v0.31.0) (2020-04-21)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -39,5 +39,5 @@
   "devDependencies": {
     "@nervosnetwork/ckb-types": "0.32.0"
   },
-  "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
+  "gitHead": "9895c230bf5782db4cc19bb51d42cb0ef62dcebc"
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,11 +33,11 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.31.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.32.0",
     "axios": "0.19.2"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.31.0"
+    "@nervosnetwork/ckb-types": "0.32.0"
   },
   "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
 }

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)
+
+
+### Features
+
+* **utils:** add convertors of uint-to-le ([16b6d80](https://github.com/nervosnetwork/ckb-sdk-js/commit/16b6d80f612a175aa6a72ad6324c89d5664fca94))
+
+
+
+
+
 # [0.31.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.30.0...v0.31.0) (2020-04-21)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/__tests__/const.test.js
+++ b/packages/ckb-sdk-utils/__tests__/const.test.js
@@ -1,0 +1,9 @@
+const { TextDecoder } = require('util')
+const { PERSONAL } = require('../lib/const')
+
+describe('Test constants', () => {
+  it('PERSONAL should be encoded ckb-default-hash', () => {
+    const decoded = new TextDecoder().decode(PERSONAL)
+    expect(decoded).toBe('ckb-default-hash')
+  })
+})

--- a/packages/ckb-sdk-utils/__tests__/convertors/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/convertors/fixtures.json
@@ -5,6 +5,10 @@
       "expected": "0xcdab"
     },
     {
+      "value": "0xbcd",
+      "expected": "0xcd0b"
+    },
+    {
       "value": "0x00cd",
       "expected": "0xcd00"
     },
@@ -89,6 +93,60 @@
     {
       "value": "hi",
       "exception": "Hex string hi should start with 0x"
+    }
+  ],
+  "hexToBytes": [
+    {
+      "hex": "",
+      "expected": []
+    },
+    {
+      "hex": "0xabcd12",
+      "expected": [
+        171,
+        205,
+        18
+      ]
+    },
+    {
+      "hex": 11259154,
+      "expected": [
+        171,
+        205,
+        18
+      ]
+    }
+  ],
+  "bytesToHex": [
+    {
+      "bytes": [
+        171,
+        205,
+        18
+      ],
+      "expected": "0xabcd12"
+    }
+  ],
+  "utf8ToHex": [
+    {
+      "utf8": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "expected": "0x4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69742c2073656420646f20656975736d6f642074656d706f7220696e6369646964756e74207574206c61626f726520657420646f6c6f7265206d61676e6120616c697175612e20557420656e696d206164206d696e696d2076656e69616d2c2071756973206e6f737472756420657865726369746174696f6e20756c6c616d636f206c61626f726973206e69736920757420616c697175697020657820656120636f6d6d6f646f20636f6e7365717561742e2044756973206175746520697275726520646f6c6f7220696e20726570726568656e646572697420696e20766f6c7570746174652076656c697420657373652063696c6c756d20646f6c6f726520657520667567696174206e756c6c612070617269617475722e204578636570746575722073696e74206f6363616563617420637570696461746174206e6f6e2070726f6964656e742c2073756e7420696e2063756c706120717569206f666669636961206465736572756e74206d6f6c6c697420616e696d20696420657374206c61626f72756d2e"
+    }
+  ],
+  "hexToUtf8": [
+    {
+      "hex": "0x4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69742c2073656420646f20656975736d6f642074656d706f7220696e6369646964756e74207574206c61626f726520657420646f6c6f7265206d61676e6120616c697175612e20557420656e696d206164206d696e696d2076656e69616d2c2071756973206e6f737472756420657865726369746174696f6e20756c6c616d636f206c61626f726973206e69736920757420616c697175697020657820656120636f6d6d6f646f20636f6e7365717561742e2044756973206175746520697275726520646f6c6f7220696e20726570726568656e646572697420696e20766f6c7570746174652076656c697420657373652063696c6c756d20646f6c6f726520657520667567696174206e756c6c612070617269617475722e204578636570746575722073696e74206f6363616563617420637570696461746174206e6f6e2070726f6964656e742c2073756e7420696e2063756c706120717569206f666669636961206465736572756e74206d6f6c6c697420616e696d20696420657374206c61626f72756d2e",
+      "expected": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    }
+  ],
+  "toHexInLittleEndian": [
+    {
+      "value": "0x3e8",
+      "expected": "0xe8030000"
+    },
+    {
+      "value": 1000,
+      "expected": "0xe8030000"
     }
   ]
 }

--- a/packages/ckb-sdk-utils/__tests__/convertors/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/convertors/fixtures.json
@@ -1,0 +1,94 @@
+{
+  "uint16Le": [
+    {
+      "value": "0xabcd",
+      "expected": "0xcdab"
+    },
+    {
+      "value": "0x00cd",
+      "expected": "0xcd00"
+    },
+    {
+      "value": "0xab00",
+      "expected": "0x00ab"
+    },
+    {
+      "value": "0x0bc0",
+      "expected": "0xc00b"
+    },
+    {
+      "value": 6,
+      "exception": "6 should be type of string or bigint"
+    },
+    {
+      "value": "ab",
+      "exception": "Hex string ab should start with 0x"
+    },
+    {
+      "value": "hi",
+      "exception": "Hex string hi should start with 0x"
+    }
+  ],
+  "uint32Le": [
+    {
+      "value": "0x12345678",
+      "expected": "0x78563412"
+    },
+    {
+      "value": "0x12345608",
+      "expected": "0x08563412"
+    },
+    {
+      "value": 6,
+      "exception": "6 should be type of string or bigint"
+    },
+    {
+      "value": "ab",
+      "exception": "Hex string ab should start with 0x"
+    },
+    {
+      "value": "hi",
+      "exception": "Hex string hi should start with 0x"
+    }
+  ],
+  "littleHexToInt": [
+    {
+      "value": "0x120100",
+      "expected": 274
+    },
+    {
+      "value": "12",
+      "exception": "12 should be type of string or bigint"
+    },
+    {
+      "value": "ab",
+      "exception": "Hex string ab should start with 0x"
+    },
+    {
+      "value": "hi",
+      "exception": "Hex string hi should start with 0x"
+    }
+  ],
+  "uint64Le": [
+    {
+      "value": "0x1234567890abcdef",
+      "expected": "0xefcdab9078563412"
+    },
+    {
+      "value": "0x3e8",
+      "expected": "0xe803000000000000"
+    },
+    {
+      "value": 6,
+      "exception": "6 should be type of string or bigint"
+    },
+    {
+      "value": "ab",
+      "exception": "Hex string ab should start with 0x"
+    },
+    {
+      "value": "hi",
+      "exception": "Hex string hi should start with 0x"
+    }
+  ]
+}

--- a/packages/ckb-sdk-utils/__tests__/convertors/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/convertors/index.test.js
@@ -1,0 +1,45 @@
+const { toUint16Le, toUint32Le, toUint64Le } = require('../../lib/convertors')
+
+const { uint16Le: uint16LeFixture, uint32Le: uint32LeFixture, uint64Le: uint64LeFixture } = require('./fixtures.json')
+
+describe('Test toUint16Le', () => {
+  const fixtureTable = uint16LeFixture.map(({ value, expected, exception }) => [value, expected, exception])
+  test.each(fixtureTable)(`%s => %s ? %s`, (value, expected, exception) => {
+    if (exception) {
+      expect(() => toUint16Le(value)).toThrow(exception)
+    } else {
+      const actualFromStr = toUint16Le(value)
+      const actualFromBigInt = toUint16Le(BigInt(value))
+      expect(actualFromStr).toBe(expected)
+      expect(actualFromBigInt).toBe(expected)
+    }
+  })
+})
+
+describe('Test toUint32Le', () => {
+  const fixtureTable = uint32LeFixture.map(({ value, expected, exception }) => [value, expected, exception])
+  test.each(fixtureTable)(`%s => %s ? %s`, (value, expected, exception) => {
+    if (exception) {
+      expect(() => toUint32Le(value)).toThrow(exception)
+    } else {
+      const actualFromStr = toUint32Le(value)
+      const actualFromBigInt = toUint32Le(BigInt(value))
+      expect(actualFromStr).toBe(expected)
+      expect(actualFromBigInt).toBe(expected)
+    }
+  })
+})
+
+describe('Test toUint64Le', () => {
+  const fixtureTable = uint64LeFixture.map(({ value, expected, exception }) => [value, expected, exception])
+  test.each(fixtureTable)(`%s => %s ? %s`, (value, expected, exception) => {
+    if (exception) {
+      expect(() => toUint64Le(value)).toThrow(exception)
+    } else {
+      const actualFromStr = toUint64Le(value)
+      const actualFromBigInt = toUint64Le(BigInt(value))
+      expect(actualFromStr).toBe(expected)
+      expect(actualFromBigInt).toBe(expected)
+    }
+  })
+})

--- a/packages/ckb-sdk-utils/__tests__/convertors/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/convertors/index.test.js
@@ -1,6 +1,25 @@
-const { toUint16Le, toUint32Le, toUint64Le } = require('../../lib/convertors')
+const {
+  toUint16Le,
+  toUint32Le,
+  toUint64Le,
+  hexToBytes,
+  bytesToHex,
+  utf8ToHex,
+  hexToUtf8,
+  toHexInLittleEndian,
+} = require('../../lib/convertors')
+const { HexStringShouldStartWith0x } = require('../../lib/exceptions')
 
-const { uint16Le: uint16LeFixture, uint32Le: uint32LeFixture, uint64Le: uint64LeFixture } = require('./fixtures.json')
+const {
+  uint16Le: uint16LeFixture,
+  uint32Le: uint32LeFixture,
+  uint64Le: uint64LeFixture,
+  hexToBytes: hexToBytesFixture,
+  bytesToHex: bytesToHexFixture,
+  utf8ToHex: utf8ToHexFixture,
+  hexToUtf8: hexToUtf8Fixture,
+  toHexInLittleEndian: toHexInLittleEndianFixture,
+} = require('./fixtures.json')
 
 describe('Test toUint16Le', () => {
   const fixtureTable = uint16LeFixture.map(({ value, expected, exception }) => [value, expected, exception])
@@ -41,5 +60,57 @@ describe('Test toUint64Le', () => {
       expect(actualFromStr).toBe(expected)
       expect(actualFromBigInt).toBe(expected)
     }
+  })
+})
+
+describe('hex to bytes', () => {
+  const fixtureTable = hexToBytesFixture.map(({ hex, expected }) => [hex, expected])
+  test.each(fixtureTable)('%s => %j', (hex, exptected) => {
+    expect(hexToBytes(hex).join(',')).toBe(exptected.join(','))
+  })
+
+  it('hex string without 0x should throw an error', () => {
+    expect(() => hexToBytes('abcd12')).toThrow(new HexStringShouldStartWith0x('abcd12'))
+  })
+})
+
+describe('bytes to hex', () => {
+  const fixtureTable = bytesToHexFixture.map(({ bytes, expected }) => [bytes, expected])
+  test.each(fixtureTable)('%j => %s', (bytes, expected) => {
+    expect(bytesToHex(bytes)).toEqual(expected)
+  })
+})
+
+describe('utf8 to hex', () => {
+  const fixtureTable = utf8ToHexFixture.map(({ utf8, expected }) => [utf8, expected])
+  test.each(fixtureTable)('%s => %s', (utf8, expected) => {
+    expect(utf8ToHex(utf8)).toBe(expected)
+  })
+})
+
+describe('hex to utf8', () => {
+  const fixtureTable = hexToUtf8Fixture.map(({ hex, expected }) => [hex, expected])
+  test.each(fixtureTable)('%s => %s', (hex, expected) => {
+    expect(hexToUtf8(hex)).toBe(expected)
+  })
+
+  it('hex string without 0x should throw an error', () => {
+    expect(() => hexToBytes('abcd')).toThrow(new HexStringShouldStartWith0x('abcd'))
+  })
+})
+
+describe('Test toHexInLittleEndian', () => {
+  const fixtureTable = toHexInLittleEndianFixture.map(({ value, expected }) => [
+    typeof value === 'number' ? BigInt(value) : value,
+    expected,
+  ])
+  test.each(fixtureTable)('%s => %s', (value, expected) => {
+    expect(toHexInLittleEndian(value)).toBe(expected)
+  })
+  it('hex string without 0x should throw an error', () => {
+    expect(() => toHexInLittleEndian('123')).toThrow(new HexStringShouldStartWith0x('123'))
+  })
+  it('throw an error when received a input unable to be converted into a number', () => {
+    expect(() => toHexInLittleEndian('invalid number')).toThrow(new HexStringShouldStartWith0x('invalid number'))
   })
 })

--- a/packages/ckb-sdk-utils/__tests__/ecpair/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/ecpair/index.test.js
@@ -1,9 +1,8 @@
+const { hexToBytes } = require('../..')
 const { default: ECPair } = require('../../lib/ecpair')
-const { HexStringShouldStartWith0x } = require('../../lib/exceptions')
-const { instantiate: instantiateFixtures } = require('./ecpare.fixtures.json')
+const { ArgumentRequired, HexStringShouldStartWith0x } = require('../../lib/exceptions')
 const { sigFixtures, signRecoverableFixtures } = require('./signature.fixtures.json')
-const { hexToBytes } = require('../../lib')
-const { ArgumentRequired } = require('../../lib/exceptions')
+const { instantiate: instantiateFixtures } = require('./ecpare.fixtures.json')
 
 describe('ECPair', () => {
   it('new ecpair', () => {

--- a/packages/ckb-sdk-utils/__tests__/utils/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/utils/index.test.js
@@ -3,7 +3,6 @@ const exceptions = require('../../lib/exceptions')
 const bech32Fixtures = require('./bech32.fixtures.json')
 const blake2bFixtures = require('./blake2b.fixtures.json')
 const rawTransactionToHashFixtures = require('./rawTransactionToHash.fixtures.json')
-const transformerFixtures = require('./transformer.fixtures.json')
 const transactionFeeFixtures = require('./transactionFee.fixtures.json')
 const transactionSizeFixture = require('./transactionSize.fixture.json')
 
@@ -20,12 +19,9 @@ const {
   parseEpoch,
   hexToBytes,
   bytesToHex,
-  utf8ToHex,
-  hexToUtf8,
   scriptToHash,
   rawTransactionToHash,
   PERSONAL,
-  toHexInLittleEndian,
   AddressType,
   fullPayloadToAddress,
   calculateTransactionFee,
@@ -33,60 +29,6 @@ const {
 } = ckbUtils
 
 const { ArgumentRequired, HexStringShouldStartWith0x } = exceptions
-
-describe('transformer', () => {
-  describe('hex to bytes', () => {
-    const fixtureTable = transformerFixtures.hexToBytes.map(({ hex, expected }) => [hex, expected])
-    test.each(fixtureTable)('%s => %j', (hex, exptected) => {
-      expect(hexToBytes(hex).join(',')).toBe(exptected.join(','))
-    })
-
-    it('hex string without 0x should throw an error', () => {
-      expect(() => hexToBytes('abcd12')).toThrow(new HexStringShouldStartWith0x('abcd12'))
-    })
-  })
-
-  describe('bytes to hex', () => {
-    const fixtureTable = transformerFixtures.bytesToHex.map(({ bytes, expected }) => [bytes, expected])
-    test.each(fixtureTable)('%j => %s', (bytes, expected) => {
-      expect(bytesToHex(bytes)).toEqual(expected)
-    })
-  })
-
-  describe('utf8 to hex', () => {
-    const fixtureTable = transformerFixtures.utf8ToHex.map(({ utf8, expected }) => [utf8, expected])
-    test.each(fixtureTable)('%s => %s', (utf8, expected) => {
-      expect(utf8ToHex(utf8)).toBe(expected)
-    })
-  })
-
-  describe('hex to utf8', () => {
-    const fixtureTable = transformerFixtures.hexToUtf8.map(({ hex, expected }) => [hex, expected])
-    test.each(fixtureTable)('%s => %s', (hex, expected) => {
-      expect(hexToUtf8(hex)).toBe(expected)
-    })
-
-    it('hex string without 0x should throw an error', () => {
-      expect(() => hexToBytes('abcd')).toThrow(new HexStringShouldStartWith0x('abcd'))
-    })
-  })
-
-  describe('Test toHexInLittleEndian', () => {
-    const fixtureTable = transformerFixtures.toHexInLittleEndian.map(({ value, expected }) => [
-      typeof value === 'number' ? BigInt(value) : value,
-      expected,
-    ])
-    test.each(fixtureTable)('%s => %s', (value, expected) => {
-      expect(toHexInLittleEndian(value)).toBe(expected)
-    })
-    it('hex string without 0x should throw an error', () => {
-      expect(() => toHexInLittleEndian('123')).toThrow(new HexStringShouldStartWith0x('123'))
-    })
-    it('throw an error when received a input unable to be converted into a number', () => {
-      expect(() => toHexInLittleEndian('invalid number')).toThrow(new HexStringShouldStartWith0x('invalid number'))
-    })
-  })
-})
 
 describe('parse epoch', () => {
   const fixture = {
@@ -158,7 +100,7 @@ describe('blake', () => {
 })
 
 describe('bech32', () => {
-  bech32Fixtures.bech32.valid.forEach(f => {
+  bech32Fixtures.bech32.valid.forEach((f) => {
     it(`fromWords/toWords ${f.hex}`, () => {
       if (f.hex) {
         const words = bech32.toWords(Buffer.from(f.hex, 'hex'))
@@ -217,7 +159,7 @@ describe('scriptToHash', () => {
       scriptHash: '0xd39f84d4702f53cf8625da4411be1640b961715cb36816501798fedb70b6e0fb',
     },
   }
-  test.each(Object.keys(fixtures))('%s', fixtureName => {
+  test.each(Object.keys(fixtures))('%s', (fixtureName) => {
     const fixture = fixtures[fixtureName]
     const scriptHash = scriptToHash(fixture.script)
     expect(scriptHash).toBe(fixture.scriptHash)
@@ -380,7 +322,7 @@ describe('address', () => {
       address: 'ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83',
     },
   }
-  test.each(Object.keys(pubkeyToAddressFixtures))('%s', caseName => {
+  test.each(Object.keys(pubkeyToAddressFixtures))('%s', (caseName) => {
     const fixture = pubkeyToAddressFixtures[caseName]
     const address = pubkeyToAddress(hexToBytes(fixture.pubkey), fixture.config)
     expect(address).toBe(fixture.address)
@@ -412,15 +354,15 @@ describe('address', () => {
 })
 
 describe('transaction fee', () => {
-  const fixtureTable = Object.entries(transactionFeeFixtures).map(
-    ([title, { transactionSize, feeRate, expected, exception }]) => [
-      title,
-      typeof transactionSize === 'number' ? BigInt(transactionSize) : transactionSize,
-      typeof feeRate === 'number' ? BigInt(feeRate) : feeRate,
-      expected,
-      exception,
-    ],
-  )
+  const fixtureTable = Object.entries(
+    transactionFeeFixtures,
+  ).map(([title, { transactionSize, feeRate, expected, exception }]) => [
+    title,
+    typeof transactionSize === 'number' ? BigInt(transactionSize) : transactionSize,
+    typeof feeRate === 'number' ? BigInt(feeRate) : feeRate,
+    expected,
+    exception,
+  ])
   test.each(fixtureTable)('%s', (_title, transactionSize, feeRate, expected, exception) => {
     if (undefined !== expected) {
       expect(calculateTransactionFee(transactionSize, feeRate)).toBe(expected)

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.31.0",
+    "@nervosnetwork/ckb-types": "0.32.0",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.2",
     "jsbi": "3.1.2"

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -41,5 +41,5 @@
     "@types/elliptic": "6.4.12",
     "@types/utf8": "2.1.6"
   },
-  "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
+  "gitHead": "9895c230bf5782db4cc19bb51d42cb0ef62dcebc"
 }

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -1,4 +1,5 @@
-import { bech32, blake160, hexToBytes, bytesToHex } from '..'
+import { bech32, blake160 } from '..'
+import { hexToBytes, bytesToHex } from '../convertors'
 import { HexStringShouldStartWith0x } from '../exceptions'
 
 export enum AddressPrefix {

--- a/packages/ckb-sdk-utils/src/const.ts
+++ b/packages/ckb-sdk-utils/src/const.ts
@@ -1,0 +1,9 @@
+/**
+ * Encoded string 'ckb-default-hash'
+ *
+ * @constant
+ * @type {bytes}
+ */
+export const PERSONAL = new Uint8Array([99, 107, 98, 45, 100, 101, 102, 97, 117, 108, 116, 45, 104, 97, 115, 104])
+
+export default { PERSONAL }

--- a/packages/ckb-sdk-utils/src/convertors/index.ts
+++ b/packages/ckb-sdk-utils/src/convertors/index.ts
@@ -1,0 +1,46 @@
+import { assertToBeHexStringOrBigint } from '../validators'
+
+/**
+ * Converts an uint16 into a hex string in little endian
+ *
+ * @memberof convertors
+ * @param {string|bigint} uint16 The uint16 to convert
+ * @returns {string} Returns a hex string
+ */
+export const toUint16Le = (uint16: string | bigint) => {
+  assertToBeHexStringOrBigint(uint16)
+  const dv = new DataView(new ArrayBuffer(2))
+  dv.setUint16(0, Number(uint16), true)
+  return `0x${dv.getUint16(0, false).toString(16).padStart(4, '0')}`
+}
+
+/**
+ * Converts an uint32 into a hex string in little endian
+ *
+ * @memberof convertors
+ * @param {string|bigint} uint32 The uint32 to convert
+ * @returns {string} Returns a hex string
+ */
+export const toUint32Le = (uint32: string | bigint) => {
+  assertToBeHexStringOrBigint(uint32)
+  const dv = new DataView(new ArrayBuffer(4))
+  dv.setUint32(0, Number(uint32), true)
+  return `0x${dv.getUint32(0, false).toString(16).padStart(8, '0')}`
+}
+
+/**
+ * Converts an uint64 into a hex string in little endian
+ *
+ * @memberof convertors
+ * @param {string|bigint} uint64 The uint64 to convert
+ * @returns {string} Returns a hex string
+ */
+export const toUint64Le = (uint64: string | bigint) => {
+  assertToBeHexStringOrBigint(uint64)
+  const val = (typeof uint64 === 'bigint' ? uint64.toString(16) : uint64.slice(2)).padStart(16, '0')
+  const viewRight = toUint32Le(`0x${val.slice(0, 8)}`).slice(2)
+  const viewLeft = toUint32Le(`0x${val.slice(8)}`).slice(2)
+  return `0x${viewLeft}${viewRight}`
+}
+
+export default { toUint16Le, toUint32Le, toUint64Le }

--- a/packages/ckb-sdk-utils/src/crypto/blake160.ts
+++ b/packages/ckb-sdk-utils/src/crypto/blake160.ts
@@ -1,5 +1,6 @@
 import blake2b from './blake2b'
-import { PERSONAL, hexToBytes } from '../index'
+import { hexToBytes } from '../convertors'
+import { PERSONAL } from '../const'
 
 export declare interface Blake160 {
   (data: Uint8Array | string): Uint8Array

--- a/packages/ckb-sdk-utils/src/ecpair.ts
+++ b/packages/ckb-sdk-utils/src/ecpair.ts
@@ -1,6 +1,6 @@
 import { ec as EC } from 'elliptic'
 
-import { hexToBytes } from '.'
+import { hexToBytes } from './convertors'
 import { HexStringShouldStartWith0x, ArgumentRequired } from './exceptions'
 
 const ec = new EC('secp256k1')

--- a/packages/ckb-sdk-utils/src/index.ts
+++ b/packages/ckb-sdk-utils/src/index.ts
@@ -10,6 +10,7 @@ import { serializeRawTransaction, serializeTransaction, serializeWitnessArgs } f
 
 export * from './address'
 export * from './serialization'
+export * from './convertors'
 export { serializeScript, serializeRawTransaction, serializeTransaction, serializeWitnessArgs }
 
 declare const TextDecoder: any // should be removed when the type definition of TextDecoder updates
@@ -77,11 +78,7 @@ export const rawTransactionToHash = (rawTransaction: Omit<CKBComponents.RawTrans
   return `0x${digest}` as string
 }
 
-const reverseString = (str: string) =>
-  str
-    .split('')
-    .reverse()
-    .join('')
+const reverseString = (str: string) => str.split('').reverse().join('')
 
 export const toHexInLittleEndian = (int: string | bigint, paddingBytes: number = 4) => {
   assertToBeHexStringOrBigint(int)
@@ -89,7 +86,7 @@ export const toHexInLittleEndian = (int: string | bigint, paddingBytes: number =
   const reversedHex = reverseString(hex)
   const frags = reversedHex.match(/\w{1,2}/g) || []
   const hexInLittleEndian = frags
-    .map(frag => reverseString(frag.padEnd(2, '0')))
+    .map((frag) => reverseString(frag.padEnd(2, '0')))
     .join('')
     .padEnd(paddingBytes * 2, '0')
   return `0x${hexInLittleEndian}`

--- a/packages/ckb-sdk-utils/src/index.ts
+++ b/packages/ckb-sdk-utils/src/index.ts
@@ -80,7 +80,13 @@ export const rawTransactionToHash = (rawTransaction: Omit<CKBComponents.RawTrans
 
 const reverseString = (str: string) => str.split('').reverse().join('')
 
+/**
+ * @deprecated since version 0.32,
+ *             will be removed in version 0.35,
+ *             use utils.{toUint16Le, toUint32Le, toUint64Le} instead
+ */
 export const toHexInLittleEndian = (int: string | bigint, paddingBytes: number = 4) => {
+  console.warn(`utils.toHexInLittleEndian is deprecated, use utils.{toUint16Le, toUint32Le, toUint64Le} instead`)
   assertToBeHexStringOrBigint(int)
   const hex = JSBI.BigInt(`${int}`).toString(16)
   const reversedHex = reverseString(hex)

--- a/packages/ckb-sdk-utils/src/index.ts
+++ b/packages/ckb-sdk-utils/src/index.ts
@@ -1,63 +1,19 @@
-import * as util from 'util'
 import JSBI from 'jsbi'
 import ECPair from './ecpair'
+import { hexToBytes } from './convertors'
 import { pubkeyToAddress, AddressOptions } from './address'
 import { assertToBeHexStringOrBigint } from './validators'
-import { HexStringShouldStartWith0x, ArgumentRequired } from './exceptions'
+import { ArgumentRequired } from './exceptions'
 import crypto from './crypto'
 import { serializeScript } from './serialization/script'
 import { serializeRawTransaction, serializeTransaction, serializeWitnessArgs } from './serialization/transaction'
+import { PERSONAL } from './const'
 
 export * from './address'
 export * from './serialization'
 export * from './convertors'
-export { serializeScript, serializeRawTransaction, serializeTransaction, serializeWitnessArgs }
 
-declare const TextDecoder: any // should be removed when the type definition of TextDecoder updates
-declare const TextEncoder: any // should be removed when the type definition of TextEncoder updates
-const textEncoder = new (typeof TextEncoder !== 'undefined' ? TextEncoder : util.TextEncoder)()
-const textDecoder = new (typeof TextDecoder !== 'undefined' ? TextDecoder : util.TextDecoder)()
-export { JSBI }
-
-export const hexToBytes = (rawhex: string | number) => {
-  if (rawhex === '') return new Uint8Array()
-  if (typeof rawhex === 'string' && !rawhex.startsWith('0x')) {
-    throw new HexStringShouldStartWith0x(rawhex)
-  }
-  let hex = rawhex.toString(16)
-
-  hex = hex.replace(/^0x/i, '')
-  hex = hex.length % 2 ? `0${hex}` : hex
-
-  const bytes = []
-  for (let c = 0; c < hex.length; c += 2) {
-    bytes.push(parseInt(hex.substr(c, 2), 16))
-  }
-
-  return new Uint8Array(bytes)
-}
-
-export const bytesToHex = (bytes: Uint8Array): string => {
-  const hex = []
-  /* eslint-disabled */
-  for (let i = 0; i < bytes.length; i++) {
-    hex.push((bytes[i] >>> 4).toString(16))
-    hex.push((bytes[i] & 0xf).toString(16))
-  }
-  /* eslint-enabled */
-  return `0x${hex.join('')}`
-}
-
-export const bytesToUtf8 = (bytes: Uint8Array) => textDecoder.decode(bytes)
-
-export const hexToUtf8 = (hex: string) => bytesToUtf8(hexToBytes(hex))
-
-export const utf8ToBytes = (str: string) => textEncoder.encode(str)
-
-export const utf8ToHex = (str: string) => bytesToHex(utf8ToBytes(str))
-
-export const PERSONAL = textEncoder.encode('ckb-default-hash')
-
+export { serializeScript, serializeRawTransaction, serializeTransaction, serializeWitnessArgs, JSBI, PERSONAL }
 export const { blake2b, bech32, blake160 } = crypto
 
 export const scriptToHash = (script: CKBComponents.Script) => {
@@ -76,26 +32,6 @@ export const rawTransactionToHash = (rawTransaction: Omit<CKBComponents.RawTrans
   s.update(hexToBytes(serializedRawTransaction))
   const digest = s.digest('hex')
   return `0x${digest}` as string
-}
-
-const reverseString = (str: string) => str.split('').reverse().join('')
-
-/**
- * @deprecated since version 0.32,
- *             will be removed in version 0.35,
- *             use utils.{toUint16Le, toUint32Le, toUint64Le} instead
- */
-export const toHexInLittleEndian = (int: string | bigint, paddingBytes: number = 4) => {
-  console.warn(`utils.toHexInLittleEndian is deprecated, use utils.{toUint16Le, toUint32Le, toUint64Le} instead`)
-  assertToBeHexStringOrBigint(int)
-  const hex = JSBI.BigInt(`${int}`).toString(16)
-  const reversedHex = reverseString(hex)
-  const frags = reversedHex.match(/\w{1,2}/g) || []
-  const hexInLittleEndian = frags
-    .map((frag) => reverseString(frag.padEnd(2, '0')))
-    .join('')
-    .padEnd(paddingBytes * 2, '0')
-  return `0x${hexInLittleEndian}`
 }
 
 export const privateKeyToPublicKey = (privateKey: string) => {

--- a/packages/ckb-sdk-utils/src/serialization/index.ts
+++ b/packages/ckb-sdk-utils/src/serialization/index.ts
@@ -1,4 +1,5 @@
-import { hexToBytes, bytesToHex, toHexInLittleEndian } from '..'
+import { hexToBytes, bytesToHex } from '..'
+import { toUint32Le } from '../convertors'
 
 export type FieldType = 'array' | 'struct' | 'fixvec' | 'dynvec' | 'table' | 'option' | 'union'
 
@@ -63,7 +64,7 @@ export const serializeFixVec = (fixVec: string | (string | Uint8Array)[]) => {
   }
   const vec = typeof fixVec === 'string' ? [...hexToBytes(fixVec)].map(b => `0x${b.toString(16)}`) : fixVec
   const serializedItemVec = vec.map(item => serializeArray(item).slice(2))
-  const header = toHexInLittleEndian(`0x${serializedItemVec.length.toString(16)}`).slice(2)
+  const header = toUint32Le(`0x${serializedItemVec.length.toString(16)}`).slice(2)
   return `0x${header}${serializedItemVec.join('')}`
 }
 
@@ -84,11 +85,11 @@ export const serializeDynVec = (dynVec: (string | Uint8Array)[]) => {
   let offsets = ''
   if (serializedItemVec.length) {
     offsets = getOffsets(serializedItemVec.map(item => item.length / 2))
-      .map(offset => toHexInLittleEndian(`0x${offset.toString(16)}`).slice(2))
+      .map(offset => toUint32Le(`0x${offset.toString(16)}`).slice(2))
       .join('')
   }
   const headerLength = fullLengthSize + offsetSize * serializedItemVec.length
-  const fullLength = toHexInLittleEndian(`0x${(headerLength + body.length / 2).toString(16)}`).slice(2)
+  const fullLength = toUint32Le(`0x${(headerLength + body.length / 2).toString(16)}`).slice(2)
   return `0x${fullLength}${offsets}${body}`
 }
 
@@ -104,9 +105,9 @@ export const serializeTable = (table: Map<string, string | Uint8Array>) => {
   })
   const body = bodyElms.join('')
   const headerLength = fullLengthSize + offsetSize * table.size
-  const fullLength = toHexInLittleEndian(`0x${(headerLength + body.length / 2).toString(16)}`).slice(2)
+  const fullLength = toUint32Le(`0x${(headerLength + body.length / 2).toString(16)}`).slice(2)
   const offsets = getOffsets(bodyElms.map(arg => arg.length / 2))
-    .map(offset => toHexInLittleEndian(`0x${offset.toString(16)}`).slice(2))
+    .map(offset => toUint32Le(`0x${offset.toString(16)}`).slice(2))
     .join('')
   return `0x${fullLength}${offsets}${body}`
 }

--- a/packages/ckb-sdk-utils/src/serialization/index.ts
+++ b/packages/ckb-sdk-utils/src/serialization/index.ts
@@ -1,5 +1,4 @@
-import { hexToBytes, bytesToHex } from '..'
-import { toUint32Le } from '../convertors'
+import { hexToBytes, bytesToHex, toUint32Le } from '../convertors'
 
 export type FieldType = 'array' | 'struct' | 'fixvec' | 'dynvec' | 'table' | 'option' | 'union'
 

--- a/packages/ckb-sdk-utils/src/serialization/transaction.ts
+++ b/packages/ckb-sdk-utils/src/serialization/transaction.ts
@@ -6,7 +6,10 @@ export const serializeVersion = (version: CKBComponents.Version) => toUint32Le(v
 
 export const serializeOutPoint = (outPoint: CKBComponents.OutPoint | null) => {
   if (!outPoint) return ''
-  const struct = new Map<string, string>([['txHash', outPoint.txHash], ['index', toUint32Le(outPoint.index)]])
+  const struct = new Map<string, string>([
+    ['txHash', outPoint.txHash],
+    ['index', toUint32Le(outPoint.index)],
+  ])
   return serializeStruct(struct)
 }
 
@@ -19,7 +22,10 @@ export const serializeDepType = (type: CKBComponents.DepType) => {
 export const serializeCellDep = (dep: CKBComponents.CellDep) => {
   const serializedOutPoint = serializeOutPoint(dep.outPoint)
   const serializedDepType = serializeDepType(dep.depType)
-  const struct = new Map<string, string>([['outPoint', serializedOutPoint], ['depType', serializedDepType]])
+  const struct = new Map<string, string>([
+    ['outPoint', serializedOutPoint],
+    ['depType', serializedDepType],
+  ])
   return serializeStruct(struct)
 }
 
@@ -37,7 +43,10 @@ export const serializeHeaderDeps = (deps: CKBComponents.Hash256[]) => {
 export const serializeInput = (input: CKBComponents.CellInput) => {
   const serializedOutPoint = serializeOutPoint(input.previousOutput)
   const serializedSince = toUint64Le(input.since)
-  const struct = new Map([['since', serializedSince], ['previousOutput', serializedOutPoint]])
+  const struct = new Map([
+    ['since', serializedSince],
+    ['previousOutput', serializedOutPoint],
+  ])
   return serializeStruct(struct)
 }
 
@@ -97,7 +106,7 @@ export const serializeRawTransaction = (
   rawTransaction: Pick<
     CKBComponents.RawTransaction,
     'version' | 'cellDeps' | 'headerDeps' | 'inputs' | 'outputs' | 'outputsData'
-  >
+  >,
 ) => {
   const serializedVersion = serializeVersion(rawTransaction.version)
   const serializedCellDeps = serializeCellDeps(rawTransaction.cellDeps)
@@ -122,6 +131,9 @@ export const serializeTransaction = (rawTransaction: CKBComponents.RawTransactio
   const serializedRawTransaction = serializeRawTransaction(rawTransaction)
   const serializedWitnesses = serializeWitnesses(rawTransaction.witnesses || [])
 
-  const table = new Map([['raw', serializedRawTransaction], ['witnesses', serializedWitnesses]])
+  const table = new Map([
+    ['raw', serializedRawTransaction],
+    ['witnesses', serializedWitnesses],
+  ])
   return serializeTable(table)
 }

--- a/packages/ckb-sdk-utils/src/serialization/transaction.ts
+++ b/packages/ckb-sdk-utils/src/serialization/transaction.ts
@@ -1,12 +1,12 @@
 import { serializeScript } from './script'
-import { toHexInLittleEndian } from '..'
+import { toUint32Le, toUint64Le } from '../convertors'
 import { serializeArray, serializeStruct, serializeTable, serializeDynVec, serializeFixVec, serializeOption } from '.'
 
-export const serializeVersion = (version: CKBComponents.Version) => toHexInLittleEndian(version)
+export const serializeVersion = (version: CKBComponents.Version) => toUint32Le(version)
 
 export const serializeOutPoint = (outPoint: CKBComponents.OutPoint | null) => {
   if (!outPoint) return ''
-  const struct = new Map<string, string>([['txHash', outPoint.txHash], ['index', toHexInLittleEndian(outPoint.index)]])
+  const struct = new Map<string, string>([['txHash', outPoint.txHash], ['index', toUint32Le(outPoint.index)]])
   return serializeStruct(struct)
 }
 
@@ -36,7 +36,7 @@ export const serializeHeaderDeps = (deps: CKBComponents.Hash256[]) => {
 // TODO: add tests
 export const serializeInput = (input: CKBComponents.CellInput) => {
   const serializedOutPoint = serializeOutPoint(input.previousOutput)
-  const serializedSince = toHexInLittleEndian(input.since, 8)
+  const serializedSince = toUint64Le(input.since)
   const struct = new Map([['since', serializedSince], ['previousOutput', serializedOutPoint]])
   return serializeStruct(struct)
 }
@@ -47,7 +47,7 @@ export const serializeInputs = (inputs: CKBComponents.CellInput[]) => {
 }
 
 export const serializeOutput = (output: CKBComponents.CellOutput) => {
-  const serializedCapacity = toHexInLittleEndian(output.capacity, 8)
+  const serializedCapacity = toUint64Le(output.capacity)
   const serializedLockScript = serializeScript(output.lock)
   const serialiedTypeScript = output.type ? serializeScript(output.type) : ''
   const table = new Map([

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 # [0.31.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.30.0...v0.31.0) (2020-04-21)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-types

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "e4fba4c84097ea24aef3ec2510e8bbc60a2de532"
+  "gitHead": "9895c230bf5782db4cc19bb51d42cb0ef62dcebc"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2496,7 +2496,7 @@ commander@^4.0.1:
 
 commander@~2.20.3:
   version "2.20.3"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commitizen@4.0.3, commitizen@^4.0.3:
@@ -4010,25 +4010,15 @@ growly@^1.3.0:
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.4.0:
-  version "4.5.3"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
-  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+handlebars@^4.4.0, handlebars@^4.7.3:
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.7.3:
-  version "4.7.5"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.5.tgz#3105d3f54038976bd54e5ae0c711c70d4ed040f8"
-  integrity sha512-PiM2ZRLZ0X+CIRSX66u7tkQi3rzrlSHAuioMBI1XP8DsfDaXEA+sD7Iyyoz4QACFuhX5z+IimN+n3BFWvvgWrQ==
-  dependencies:
+    minimist "^1.2.5"
     neo-async "^2.6.0"
     source-map "^0.6.1"
-    yargs "^14.2.3"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -5763,20 +5753,15 @@ minimist@0.0.8:
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"
@@ -5921,7 +5906,7 @@ natural-compare@^1.4.0:
 
 neo-async@^2.6.0:
   version "2.6.1"
-  resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 nice-try@^1.0.4:
@@ -6214,14 +6199,6 @@ opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -8042,12 +8019,11 @@ typescript@3.8.3:
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz#cb1a601e67536e9ed094a92dd1e333459643d3f9"
-  integrity sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.3.tgz#4a285d1658b8a2ebaef9e51366b3a0f7acd79ec2"
+  integrity sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==
   dependencies:
     commander "~2.20.3"
-    source-map "~0.6.1"
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -8293,10 +8269,10 @@ word-wrap@^1.0.3, word-wrap@~1.2.3:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wrap-ansi@^3.0.1:
   version "3.0.1"
@@ -8431,14 +8407,6 @@ yargs-parser@^10.0.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
-  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
@@ -8456,23 +8424,6 @@ yargs-parser@^18.1.1:
     decamelize "^1.2.0"
 
 yargs@^14.2.2:
-  version "14.2.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz#2769564379009ff8597cdd38fba09da9b493c4b5"
-  integrity sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.0"
-
-yargs@^14.2.3:
   version "14.2.3"
   resolved "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
   integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==


### PR DESCRIPTION
# [0.32.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.31.0...v0.32.0) (2020-05-26)


### Features

* **utils:** add convertors of uint-to-le ([16b6d80](https://github.com/nervosnetwork/ckb-sdk-js/commit/16b6d80f612a175aa6a72ad6324c89d5664fca94))
* use signature provider in signWitnesses & signWitnessGroup ([#434](https://github.com/nervosnetwork/ckb-sdk-js/issues/434)) ([34d62bb](https://github.com/nervosnetwork/ckb-sdk-js/commit/34d62bb9c86b680e5887194131379c2a01b4f068))