### PR TITLE
Fix rpc api

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "bootstrap": "lerna bootstrap",
     "tsc": "lerna run tsc",
     "cm": "git-cz",
-    "cli": "./packages/ckb-cli/lib/index.js i",
+    "build:lib": "lerna run tsc",
+    "clean:lib": "rimraf **/packages/*/lib",
     "docs": "typedoc --out docs --mode file --includes packages --name CKB-SDK.js --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md",
     "publish": "lerna run tsc && lerna publish --from-package",
     "test": "jest --coverage"
@@ -42,6 +43,7 @@
     "lerna": "3.20.2",
     "lint-staged": "10.1.1",
     "prettier": "2.0.2",
+    "rimraf": "3.0.2",
     "typedoc": "0.17.3",
     "typescript": "3.8.3"
   },

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -1,179 +1,1279 @@
-const http = require('http')
+/* eslint-disable max-len */
 
-const httpAgent = new http.Agent({ keepAlive: true })
+jest.mock('axios')
 
-const NODE_URL = 'http://localhost:8114'
-
+const axiosMock = require('axios')
 const CKBRPC = require('../lib').default
 
-const rpc = new CKBRPC(NODE_URL)
-rpc.setNode({ httpAgent })
+describe('Test with mock', () => {
+  const rpc = new CKBRPC()
+  const ranNum = 1
+  const id = Math.round(ranNum * 10000)
 
-describe('ckb-rpc success', () => {
-  it('get blockchain info', async () => {
-    const info = await rpc.getBlockchainInfo()
-    expect(info).not.toBe(undefined)
+  beforeAll(() => {
+    jest.spyOn(global.Math, 'random').mockReturnValue(ranNum)
   })
 
-  it('local node info', async () => {
-    const info = await rpc.localNodeInfo()
-    expect(typeof info.nodeId).toBe('string')
+  afterAll(() => {
+    jest.restoreAllMocks()
   })
 
-  it('get peers', async () => {
-    const nodes = await rpc.getPeers()
-    expect(Array.isArray(nodes)).toBeTruthy()
-  })
-
-  it('get peers state', async () => {
-    const state = await rpc.getPeersState()
-    expect(state).not.toBe(undefined)
-  })
-
-  it('get tip block number', async () => {
-    const tipBlockNumber = await rpc.getTipBlockNumber()
-    expect(typeof tipBlockNumber).toBe('string')
-  })
-
-  it('get block hash and get block of genesis block', async () => {
-    const hash = await rpc.getBlockHash('0x0')
-    expect(hash.length).toBe(66)
-    const block = await rpc.getBlock(hash)
-    expect(block.header.hash).toBe(hash)
-  })
-
-  it('get tip block number', async () => {
-    const blockNumber = await rpc.getTipBlockNumber()
-    expect(typeof blockNumber).toBe('string')
-  })
-
-  it('get tip header', async () => {
-    const header = await rpc.getTipHeader()
-    expect(typeof header.hash).toBe('string')
-  })
-
-  it('get transaction', async () => {
-    const hash = await rpc.getBlockHash('0x0')
-    const block = await rpc.getBlock(hash)
-    const { transactions } = block
-    if (transactions.length) {
-      const txHash = transactions[0].hash
-      const { transaction, txStatus } = await rpc.getTransaction(txHash)
-      expect(transaction.hash).toBe(txHash)
-      expect(txStatus).toEqual({
-        blockHash: hash,
-        status: 'committed',
-      })
-    } else {
-      throw new Error('No transaction found')
-    }
-  })
-
-  it('get live cell', async () => {
-    const outPoint = {
-      txHash: '0xff5a36107851d244e1543821f9f039c3d4eb69d9968750b0b0e82e78da86c987',
-      index: '0x0',
-    }
-    const cellRes = await rpc.getLiveCell(outPoint, true)
-    expect(cellRes.status).toBe('unknown')
-  })
-
-  it('get cells by lock hash', async () => {
-    const lockHash = '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674'
-    const cells = await rpc.getCellsByLockHash(lockHash, '0x0', '0x64')
-    expect(Array.isArray(cells)).toBeTruthy()
-  })
-
-  it('deindex lock hash', async () => {})
-
-  it('get live cells by lock hash', async () => {})
-
-  it('get lock hash index states', async () => {})
-
-  it('get transactions by lock hash', async () => {})
-
-  it('index lock hash', async () => {})
-
-  it('get banned addresses', async () => {
-    const addresses = await rpc.getBannedAddresses()
-    expect(Array.isArray(addresses)).toBe(true)
-  })
-
-  it('set address to be banned', async () => {
-    expect.assertions(1)
-    await expect(rpc.setBan('192.168.0.2', 'insert', null)).resolves.toEqual(null)
-  })
-
-  it('get banned address', async () => {
-    const addresses = await rpc.getBannedAddresses()
-    expect(Array.isArray(addresses)).toBe(true)
-  })
-
-  it('get header', async () => {
-    const zeroBlock = await rpc.getBlockByNumber('0x0')
-    const zeroBlockHeader = zeroBlock.header
-    const zeroBlockHash = zeroBlockHeader.hash
-    const header = await rpc.getHeader(zeroBlockHash)
-    expect(header).toEqual(zeroBlockHeader)
-  })
-
-  it('get header by number', async () => {
-    const zeroBlock = await rpc.getBlockByNumber('0x0')
-    const zeroBlockHeader = zeroBlock.header
-    const header = await rpc.getHeaderByNumber('0x0')
-    expect(header).toEqual(zeroBlockHeader)
-  })
-
-  it.skip('estimate fee rate', async () => {
-    const feeRate = await rpc.estimateFeeRate('0x11')
-    expect(feeRate).toBeTruthy()
-  })
-})
-
-describe.skip('send transaction', () => {
-  it('send transaction', async () => {
-    const tx = {
-      cellDeps: [
-        {
-          outPoint: {
-            txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-            index: '0x1',
+  describe('ckb-rpc success', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    it('get block by number', async () => {
+      const BLOCK_NUMBER = '0x400'
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            header: {
+              compact_target: '0x1e083126',
+              dao: '0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000',
+              epoch: '0x7080018000001',
+              hash: '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+              nonce: '0x0',
+              number: '0x400',
+              parent_hash: '0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d',
+              proposals_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              timestamp: '0x5cd2b117',
+              transactions_root: '0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c',
+              uncles_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              version: '0x0',
+            },
+            proposals: [],
+            transactions: [
+              {
+                cell_deps: [],
+                hash: '0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17',
+                header_deps: [],
+                inputs: [
+                  {
+                    previous_output: {
+                      index: '0xffffffff',
+                      tx_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                    },
+                    since: '0x400',
+                  },
+                ],
+                outputs: [
+                  {
+                    capacity: '0x18e64b61cf',
+                    lock: {
+                      args: '0x',
+                      code_hash: '0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5',
+                      hash_type: 'data',
+                    },
+                    type: null,
+                  },
+                ],
+                outputs_data: ['0x'],
+                version: '0x0',
+                witnesses: [
+                  '0x450000000c000000410000003500000010000000300000003100000028e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5000000000000000000',
+                ],
+              },
+            ],
+            uncles: [],
           },
-          depType: 'code',
         },
-      ],
-      headerDeps: [],
-      inputs: [
+      })
+      const res = await rpc.getBlockByNumber(BLOCK_NUMBER)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_block_by_number',
+        params: [BLOCK_NUMBER],
+      })
+      expect(res).toEqual({
+        header: {
+          compactTarget: '0x1e083126',
+          dao: '0xb5a3e047474401001bc476b9ee573000c0c387962a38000000febffacf030000',
+          epoch: '0x7080018000001',
+          hash: '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+          nonce: '0x0',
+          number: '0x400',
+          parentHash: '0xae003585fa15309b30b31aed3dcf385e9472c3c3e93746a6c4540629a6a1ed2d',
+          proposalsHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          timestamp: '0x5cd2b117',
+          transactionsRoot: '0xc47d5b78b3c4c4c853e2a32810818940d0ee403423bea9ec7b8e566d9595206c',
+          unclesHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          version: '0x0',
+        },
+        proposals: [],
+        transactions: [
+          {
+            cellDeps: [],
+            hash: '0x365698b50ca0da75dca2c87f9e7b563811d3b5813736b8cc62cc3b106faceb17',
+            headerDeps: [],
+            inputs: [
+              {
+                previousOutput: {
+                  index: '0xffffffff',
+                  txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                },
+                since: '0x400',
+              },
+            ],
+            outputs: [
+              {
+                capacity: '0x18e64b61cf',
+                lock: {
+                  args: '0x',
+                  codeHash: '0x28e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5',
+                  hashType: 'data',
+                },
+                type: null,
+              },
+            ],
+            outputsData: ['0x'],
+            version: '0x0',
+            witnesses: [
+              '0x450000000c000000410000003500000010000000300000003100000028e83a1277d48add8e72fadaa9248559e1b632bab2bd60b27955ebc4c03800a5000000000000000000',
+            ],
+          },
+        ],
+        uncles: [],
+      })
+    })
+    it('tx pool info', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            last_txs_updated_at: '0x0',
+            min_fee_rate: '0x0',
+            orphan: '0x0',
+            pending: '0x1',
+            proposed: '0x0',
+            total_tx_cycles: '0x219',
+            total_tx_size: '0x112',
+          },
+        },
+      })
+      const res = await rpc.txPoolInfo()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'tx_pool_info',
+        params: [],
+      })
+      expect(res).toEqual({
+        lastTxsUpdatedAt: '0x0',
+        minFeeRate: '0x0',
+        orphan: '0x0',
+        pending: '0x1',
+        proposed: '0x0',
+        totalTxCycles: '0x219',
+        totalTxSize: '0x112',
+      })
+    })
+    it('get current epoch', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            compact_target: '0x1e083126',
+            length: '0x708',
+            number: '0x1',
+            start_number: '0x3e8',
+          },
+        },
+      })
+      const res = await rpc.getCurrentEpoch()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_current_epoch',
+        params: [],
+      })
+      expect(res).toEqual({
+        compactTarget: '0x1e083126',
+        length: '0x708',
+        number: '0x1',
+        startNumber: '0x3e8',
+      })
+    })
+    it('get epoch by number', async () => {
+      const BLOCK_NUMBER = '0x0'
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            compact_target: '0x20010000',
+            length: '0x3e8',
+            number: '0x0',
+            start_number: '0x0',
+          },
+        },
+      })
+      const res = await rpc.getEpochByNumber(BLOCK_NUMBER)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_epoch_by_number',
+        params: [BLOCK_NUMBER],
+      })
+      expect(res).toEqual({
+        compactTarget: '0x20010000',
+        length: '0x3e8',
+        number: '0x0',
+        startNumber: '0x0',
+      })
+    })
+    it.skip('dryRunTransaction', async () => {})
+    it('get cellbase output capacity details', async () => {
+      const BLOCK_HASH = '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40'
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            primary: '0x18ce922bca',
+            proposal_reward: '0x0',
+            secondary: '0x17b93605',
+            total: '0x18e64b61cf',
+            tx_fee: '0x0',
+          },
+        },
+      })
+      const res = await rpc.getCellbaseOutputCapacityDetails(BLOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_cellbase_output_capacity_details',
+        params: [BLOCK_HASH],
+      })
+      expect(res).toEqual({
+        primary: '0x18ce922bca',
+        proposalReward: '0x0',
+        secondary: '0x17b93605',
+        total: '0x18e64b61cf',
+        txFee: '0x0',
+      })
+    })
+    it('calculate dao maximum withdraw', async () => {
+      const PARAMS = [
         {
-          previousOutput: {
-            txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          index: '0x0',
+          txHash: '0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3',
+        },
+        '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+      ]
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: '0x4a8b4e8a4',
+        },
+      })
+      const res = await rpc.calculateDaoMaximumWithdraw(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'calculate_dao_maximum_withdraw',
+        params: [
+          {
+            index: '0x0',
+            tx_hash: '0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3',
+          },
+          '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+        ],
+      })
+      expect(res).toBe('0x4a8b4e8a4')
+    })
+    it('get capacity by lock hash', async () => {
+      const LOCK_HASH = '0x4ceaa32f692948413e213ce6f3a83337145bde6e11fd8cb94377ce2637dcc412'
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            block_number: '0x400',
+            capacity: '0xb00fb84df292',
+            cells_count: '0x3f5',
+          },
+        },
+      })
+      const res = await rpc.getCapacityByLockHash(LOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_capacity_by_lock_hash',
+        params: [LOCK_HASH],
+      })
+      expect(res).toEqual({
+        blockNumber: '0x400',
+        capacity: '0xb00fb84df292',
+        cellsCount: '0x3f5',
+      })
+    })
+    it('get block economic state', async () => {
+      const BLOCK_HASH = '0x02530b25ad0ff677acc365cb73de3e8cc09c7ddd58272e879252e199d08df83b'
+
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            finalized_at: '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+            issuance: {
+              primary: '0x18ce922bca',
+              secondary: '0x7f02ec655',
+            },
+            miner_reward: {
+              committed: '0x0',
+              primary: '0x18ce922bca',
+              proposal: '0x0',
+              secondary: '0x17b93605',
+            },
+            txs_fee: '0x0',
+          },
+        },
+      })
+      const res = await rpc.getBlockEconomicState(BLOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_block_economic_state',
+        params: [BLOCK_HASH],
+      })
+      expect(res).toEqual({
+        finalizedAt: '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40',
+        issuance: {
+          primary: '0x18ce922bca',
+          secondary: '0x7f02ec655',
+        },
+        minerReward: {
+          committed: '0x0',
+          primary: '0x18ce922bca',
+          proposal: '0x0',
+          secondary: '0x17b93605',
+        },
+        txsFee: '0x0',
+      })
+    })
+    it('get blockchain info', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            alerts: [],
+            chain: 'ckb_dev',
+            difficulty: '0x100',
+            epoch: '0xa00090000e2',
+            is_initial_block_download: true,
+            median_time: '0x172a87eeab0',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getBlockchainInfo()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_blockchain_info',
+        params: [],
+      })
+      expect(res).toEqual({
+        alerts: [],
+        chain: 'ckb_dev',
+        difficulty: '0x100',
+        epoch: '0xa00090000e2',
+        isInitialBlockDownload: true,
+        medianTime: '0x172a87eeab0',
+      })
+    })
+
+    it('local node info', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            addresses: [
+              {
+                address: '/ip4/0.0.0.0/tcp/8115/p2p/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+                score: '0x100',
+              },
+            ],
+            is_outbound: null,
+            node_id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            version: '0.33.0 (248aa88 2020-10-22)',
+          },
+          id,
+        },
+      })
+      const res = await rpc.localNodeInfo()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'local_node_info',
+        params: [],
+      })
+      expect(res).toEqual({
+        addresses: [
+          {
+            address: '/ip4/0.0.0.0/tcp/8115/p2p/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            score: '0x100',
+          },
+        ],
+        isOutbound: null,
+        nodeId: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        version: '0.33.0 (248aa88 2020-10-22)',
+      })
+    })
+
+    it('get peers', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [],
+          id,
+        },
+      })
+      const res = await rpc.getPeers()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_peers',
+        params: [],
+      })
+      expect(res).toEqual([])
+    })
+
+    it('get peers state', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [],
+          id,
+        },
+      })
+      const res = await rpc.getPeersState()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_peers_state',
+        params: [],
+      })
+      expect(res).toEqual({
+        blocksInFlight: undefined,
+        lastUpdated: undefined,
+      })
+    })
+
+    it('get tip block number', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: '0x8dd',
+          id,
+        },
+      })
+      const res = await rpc.getTipBlockNumber()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_tip_block_number',
+        params: [],
+      })
+      expect(res).toBe('0x8dd')
+    })
+
+    it('get block hash', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: '0x120ab9abd48e3b82f93b88eba8c50a0e1304cc2fffb5573fb14b56c6348f2305',
+          id,
+        },
+      })
+      const res = await rpc.getBlockHash('0x0')
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_block_hash',
+        params: ['0x0'],
+      })
+      expect(res).toBe('0x120ab9abd48e3b82f93b88eba8c50a0e1304cc2fffb5573fb14b56c6348f2305')
+    })
+
+    it('get block', async () => {
+      const BLOCK_HASH = '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4'
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            header: {
+              compact_target: '0x20010000',
+              dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+              epoch: '0xa00090000e2',
+              hash: BLOCK_HASH,
+              nonce: '0x3388940124a1004051e37eb039a3dfeb',
+              number: '0x8dd',
+              parent_hash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+              proposals_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              timestamp: '0x172a8804ad1',
+              transactions_root: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+              uncles_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              version: '0x0',
+            },
+            proposals: [],
+            transactions: [
+              {
+                cell_deps: [],
+                hash: '0x638f645b153c543acc63a884cf2423499bd2774b42d7dd96bd8b50ddc4b5c038',
+                header_deps: [],
+                inputs: [
+                  {
+                    previous_output: {
+                      index: '0xffffffff',
+                      tx_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                    },
+                    since: '0x8dd',
+                  },
+                ],
+                outputs: [
+                  {
+                    capacity: '0x12440cbf2a1e',
+                    lock: {
+                      args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                      code_hash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                      hash_type: 'type',
+                    },
+                    type: null,
+                  },
+                ],
+                outputs_data: ['0x'],
+                version: '0x0',
+                witnesses: [
+                  '0x5a0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000e2fa82e70b062c8644b80ad7ecf6e015e5f352f60100000000',
+                ],
+              },
+            ],
+            uncles: [],
+          },
+          id,
+        },
+      })
+
+      const res = await rpc.getBlock(BLOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_block',
+        params: [BLOCK_HASH],
+      })
+      expect(res).toEqual({
+        header: {
+          compactTarget: '0x20010000',
+          dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+          epoch: '0xa00090000e2',
+          hash: BLOCK_HASH,
+          nonce: '0x3388940124a1004051e37eb039a3dfeb',
+          number: '0x8dd',
+          parentHash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+          proposalsHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          timestamp: '0x172a8804ad1',
+          transactionsRoot: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+          unclesHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          version: '0x0',
+        },
+        proposals: [],
+        transactions: [
+          {
+            cellDeps: [],
+            hash: '0x638f645b153c543acc63a884cf2423499bd2774b42d7dd96bd8b50ddc4b5c038',
+            headerDeps: [],
+            inputs: [
+              {
+                previousOutput: {
+                  index: '0xffffffff',
+                  txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                },
+                since: '0x8dd',
+              },
+            ],
+            outputs: [
+              {
+                capacity: '0x12440cbf2a1e',
+                lock: {
+                  args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                  codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                  hashType: 'type',
+                },
+                type: null,
+              },
+            ],
+            outputsData: ['0x'],
+            version: '0x0',
+            witnesses: [
+              '0x5a0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000e2fa82e70b062c8644b80ad7ecf6e015e5f352f60100000000',
+            ],
+          },
+        ],
+        uncles: [],
+      })
+    })
+
+    it('get tip header', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            compact_target: '0x20010000',
+            dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+            epoch: '0xa00090000e2',
+            hash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+            nonce: '0x3388940124a1004051e37eb039a3dfeb',
+            number: '0x8dd',
+            parent_hash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+            proposals_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            timestamp: '0x172a8804ad1',
+            transactions_root: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+            uncles_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            version: '0x0',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getTipHeader()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_tip_header',
+        params: [],
+      })
+      expect(res).toEqual({
+        compactTarget: '0x20010000',
+        dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+        epoch: '0xa00090000e2',
+        hash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+        nonce: '0x3388940124a1004051e37eb039a3dfeb',
+        number: '0x8dd',
+        parentHash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+        proposalsHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        timestamp: '0x172a8804ad1',
+        transactionsRoot: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+        unclesHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        version: '0x0',
+      })
+    })
+
+    it('get transaction', async () => {
+      const TX_HASH = '0xc4a69f70877c2e00897191e0ca81edc8ad14ff81b8049c9d66523df7e365524f'
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            transaction: {
+              cell_deps: [],
+              hash: TX_HASH,
+              header_deps: [],
+              inputs: [
+                {
+                  previous_output: {
+                    index: '0xffffffff',
+                    tx_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  },
+                  since: '0x8dc',
+                },
+              ],
+              outputs: [
+                {
+                  capacity: '0x12440d255842',
+                  lock: {
+                    args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                    code_hash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                    hash_type: 'type',
+                  },
+                  type: null,
+                },
+              ],
+              outputs_data: ['0x'],
+              version: '0x0',
+              witnesses: [
+                '0x5a0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000e2fa82e70b062c8644b80ad7ecf6e015e5f352f60100000000',
+              ],
+            },
+            tx_status: {
+              block_hash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+              status: 'committed',
+            },
+          },
+          id,
+        },
+      })
+      const res = await rpc.getTransaction(TX_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_transaction',
+        params: [TX_HASH],
+      })
+      expect(res).toEqual({
+        transaction: {
+          cellDeps: [],
+          hash: '0xc4a69f70877c2e00897191e0ca81edc8ad14ff81b8049c9d66523df7e365524f',
+          headerDeps: [],
+          inputs: [
+            {
+              previousOutput: {
+                index: '0xffffffff',
+                txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              },
+              since: '0x8dc',
+            },
+          ],
+          outputs: [
+            {
+              capacity: '0x12440d255842',
+              lock: {
+                args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                hashType: 'type',
+              },
+              type: null,
+            },
+          ],
+          outputsData: ['0x'],
+          version: '0x0',
+          witnesses: [
+            '0x5a0000000c00000055000000490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80114000000e2fa82e70b062c8644b80ad7ecf6e015e5f352f60100000000',
+          ],
+        },
+        txStatus: {
+          blockHash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+          status: 'committed',
+        },
+      })
+    })
+
+    it('get live cell', async () => {
+      const OUT_POINT = {
+        txHash: '0xc4a69f70877c2e00897191e0ca81edc8ad14ff81b8049c9d66523df7e365524f',
+        index: '0x0',
+      }
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            cell: {
+              data: {
+                content: '0x',
+                hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              },
+              output: {
+                capacity: '0x12440d255842',
+                lock: {
+                  args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                  code_hash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                  hash_type: 'type',
+                },
+                type: null,
+              },
+            },
+            status: 'live',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getLiveCell(OUT_POINT, true)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_live_cell',
+        params: [
+          {
+            tx_hash: '0xc4a69f70877c2e00897191e0ca81edc8ad14ff81b8049c9d66523df7e365524f',
             index: '0x0',
           },
-          since: '0x0',
-        },
-      ],
-      outputs: [
-        {
-          capacity: '0x48c27395000',
-          lock: {
-            args: [],
-            codeHash: '0x0000000000000000000000000000000000000000000000000000000000000001',
-            hashType: 'data',
+          true,
+        ],
+      })
+      expect(res).toEqual({
+        cell: {
+          data: {
+            content: '0x',
+            hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           },
+          output: {
+            capacity: '0x12440d255842',
+            lock: {
+              args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+              codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+              hashType: 'type',
+            },
+            type: null,
+          },
+        },
+        status: 'live',
+      })
+    })
+
+    it('get cells by lock hash', async () => {
+      const PARAMS = ['0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674', '0x0', '0x64']
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [
+            {
+              block_hash: '0x8b5de4cad43e62fdc391d897b94a97d1af369bbe2b7cbe1de20d432da5a23f4c',
+              capacity: '0x12479afc2a35',
+              cellbase: true,
+              lock: {
+                args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                code_hash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                hash_type: 'type',
+              },
+              out_point: {
+                index: '0x0',
+                tx_hash: '0x0db670e7bab37e4f942acf47c7887009771e01b5a6b282eff32084c38533a2b2',
+              },
+              output_data_len: '0x0',
+              type: null,
+            },
+          ],
+          id,
+        },
+      })
+      const res = await rpc.getCellsByLockHash(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_cells_by_lock_hash',
+        params: PARAMS,
+      })
+      expect(res).toEqual([
+        {
+          blockHash: '0x8b5de4cad43e62fdc391d897b94a97d1af369bbe2b7cbe1de20d432da5a23f4c',
+          capacity: '0x12479afc2a35',
+          cellbase: true,
+          lock: {
+            args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+            codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+            hashType: 'type',
+          },
+          outPoint: {
+            index: '0x0',
+            txHash: '0x0db670e7bab37e4f942acf47c7887009771e01b5a6b282eff32084c38533a2b2',
+          },
+          outputDataLen: '0x0',
           type: null,
         },
-      ],
-      version: '0x0',
-      outputsData: ['0x'],
-      witnesses: [],
-    }
-    const hash = await rpc.sendTransaction(tx)
-    expect(hash).toBeTruthy()
-  })
-})
+      ])
+    })
 
-describe('ckb-rpc errors', () => {
-  it('throw raw error', async () => {
-    expect(() => rpc.getBlock(0)).toThrow()
+    it('index lock hash', async () => {
+      const PARAMS = ['0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674', '0x0']
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            block_hash: '0x8b5de4cad43e62fdc391d897b94a97d1af369bbe2b7cbe1de20d432da5a23f4c',
+            block_number: '0x18',
+            lock_hash: '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674',
+          },
+          id,
+        },
+      })
+      const res = await rpc.indexLockHash(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'index_lock_hash',
+        params: PARAMS,
+      })
+      expect(res).toEqual({
+        blockHash: '0x8b5de4cad43e62fdc391d897b94a97d1af369bbe2b7cbe1de20d432da5a23f4c',
+        blockNumber: '0x18',
+        lockHash: '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674',
+      })
+    })
+
+    it('deindex lock hash', async () => {
+      const LOCK_HASH = '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674'
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: null,
+          id,
+        },
+      })
+      const res = await rpc.deindexLockHash(LOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'deindex_lock_hash',
+        params: [LOCK_HASH],
+      })
+      expect(res).toBeNull()
+    })
+
+    it('get live cells by lock hash', async () => {
+      const PARAMS = ['0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674', '0x0', '0x10', false]
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [
+            {
+              cell_output: {
+                capacity: '0x12479d77059e',
+                lock: {
+                  args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+                  code_hash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+                  hash_type: 'type',
+                },
+                type: null,
+              },
+              cellbase: true,
+              created_by: {
+                block_number: '0x12',
+                index: '0x0',
+                tx_hash: '0xdda2f516ebfaf1d3ff5eecd65c78a22254127606339fec4a5328099ea0ddb7db',
+              },
+              output_data_len: '0x0',
+            },
+          ],
+          id,
+        },
+      })
+      const res = await rpc.getLiveCellsByLockHash(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_live_cells_by_lock_hash',
+        params: PARAMS,
+      })
+      expect(res).toEqual([
+        {
+          cellOutput: {
+            capacity: '0x12479d77059e',
+            lock: {
+              args: '0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6',
+              codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+              hashType: 'type',
+            },
+            type: null,
+          },
+          cellbase: true,
+          createdBy: {
+            blockNumber: '0x12',
+            index: '0x0',
+            txHash: '0xdda2f516ebfaf1d3ff5eecd65c78a22254127606339fec4a5328099ea0ddb7db',
+          },
+          outputDataLen: '0x0',
+        },
+      ])
+    })
+
+    it('get lock hash index states', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [
+            {
+              block_hash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+              block_number: '0x8dd',
+              lock_hash: '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674',
+            },
+          ],
+          id,
+        },
+      })
+      const res = await rpc.getLockHashIndexStates()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_lock_hash_index_states',
+        params: [],
+      })
+      expect(res).toEqual([
+        {
+          blockHash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+          blockNumber: '0x8dd',
+          lockHash: '0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674',
+        },
+      ])
+    })
+
+    it('get tranactions by lock hash', async () => {
+      const PARAMS = ['0x0da2fe99fe549e082d4ed483c2e968a89ea8d11aabf5d79e5cbf06522de6e674', '0x0', '0x10', false]
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [
+            {
+              consumed_by: {
+                block_number: '0x67c',
+                index: '0x0',
+                tx_hash: '0xfd9170c6a55095b7f878bfbddaa726446fa91414ec6fd61e8d5275451b91d854',
+              },
+              created_by: {
+                block_number: '0xc',
+                index: '0x0',
+                tx_hash: '0x5b8184b27bad1238809300cb116ad85bdd2cc1ce0736d619c1468774cf27d4ce',
+              },
+            },
+          ],
+          id,
+        },
+      })
+      const res = await rpc.getTransactionsByLockHash(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_transactions_by_lock_hash',
+        params: PARAMS,
+      })
+      expect(res).toEqual([
+        {
+          consumedBy: {
+            blockNumber: '0x67c',
+            index: '0x0',
+            txHash: '0xfd9170c6a55095b7f878bfbddaa726446fa91414ec6fd61e8d5275451b91d854',
+          },
+          createdBy: {
+            blockNumber: '0xc',
+            index: '0x0',
+            txHash: '0x5b8184b27bad1238809300cb116ad85bdd2cc1ce0736d619c1468774cf27d4ce',
+          },
+        },
+      ])
+    })
+
+    it('get banned addresses', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: [],
+          id,
+        },
+      })
+      const res = await rpc.getBannedAddresses()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_banned_addresses',
+        params: [],
+      })
+      expect(res).toEqual([])
+    })
+
+    it('set address to be banned', async () => {
+      const PARAMS = ['1.1.1.1', 'insert', null, true, 'No reason']
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: null,
+          id,
+        },
+      })
+      const res = await rpc.setBan(...PARAMS)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'set_ban',
+        params: PARAMS,
+      })
+      expect(res).toBeNull()
+    })
+
+    it('get header', async () => {
+      const BLOCK_HASH = '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4'
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            compact_target: '0x20010000',
+            dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+            epoch: '0xa00090000e2',
+            hash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+            nonce: '0x3388940124a1004051e37eb039a3dfeb',
+            number: '0x8dd',
+            parent_hash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+            proposals_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            timestamp: '0x172a8804ad1',
+            transactions_root: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+            uncles_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            version: '0x0',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getHeader(BLOCK_HASH)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_header',
+        params: [BLOCK_HASH],
+      })
+      expect(res).toEqual({
+        compactTarget: '0x20010000',
+        dao: '0xd6ec63f77d466d2fb394bcb565ac2300b14e9b080c222a0000418b05be0fff06',
+        epoch: '0xa00090000e2',
+        hash: '0x7c7f64c875b22807451620c9d1e9af460e851ffe82d85a90e1bccb1117e2e3a4',
+        nonce: '0x3388940124a1004051e37eb039a3dfeb',
+        number: '0x8dd',
+        parentHash: '0xc4537bb867ef8103c221888f134b95078bb121c9cb2b654272e6730025304b7b',
+        proposalsHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        timestamp: '0x172a8804ad1',
+        transactionsRoot: '0xcde937f363e195a97467061a45a6b5b318da02fc3fec5e76ab298e41ace0b7a1',
+        unclesHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        version: '0x0',
+      })
+    })
+
+    it('get header by number', async () => {
+      const BLOCK_NUMBER = '0x1'
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            compact_target: '0x20010000',
+            dao: '0x1d78d68e4363a12ee3e511f1fa862300f091bde0110f00000053322801fbfe06',
+            epoch: '0xa0002000000',
+            hash: '0xffd50ddb91a842234ff8f0871b941a739928c2f4a6b5cfc39de96a3f87c2413e',
+            nonce: '0x4e51c6b50fd5a1af81c1d0c770a23c93',
+            number: BLOCK_NUMBER,
+            parent_hash: '0x4aa1bf4930b2fbcebf70bd0b6cc63a19ae8554d6c7e89a666433040300641db9',
+            proposals_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            timestamp: '0x1725940cb91',
+            transactions_root: '0xcd95e31e21734fb796de0070407c1d4f91ec00d699f840e5ad9aa293443744e6',
+            uncles_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            version: '0x0',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getHeaderByNumber(BLOCK_NUMBER)
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_header_by_number',
+        params: [BLOCK_NUMBER],
+      })
+      expect(res).toEqual({
+        compactTarget: '0x20010000',
+        dao: '0x1d78d68e4363a12ee3e511f1fa862300f091bde0110f00000053322801fbfe06',
+        epoch: '0xa0002000000',
+        hash: '0xffd50ddb91a842234ff8f0871b941a739928c2f4a6b5cfc39de96a3f87c2413e',
+        nonce: '0x4e51c6b50fd5a1af81c1d0c770a23c93',
+        number: BLOCK_NUMBER,
+        parentHash: '0x4aa1bf4930b2fbcebf70bd0b6cc63a19ae8554d6c7e89a666433040300641db9',
+        proposalsHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        timestamp: '0x1725940cb91',
+        transactionsRoot: '0xcd95e31e21734fb796de0070407c1d4f91ec00d699f840e5ad9aa293443744e6',
+        unclesHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+        version: '0x0',
+      })
+    })
+
+    it.skip('estimate fee rate', async () => {
+      const res = await rpc.estimateFeeRate('0x11')
+      expect(res).toBeTruthy()
+    })
+
+    it('send transaction', async () => {
+      const tx = {
+        cellDeps: [
+          {
+            outPoint: {
+              txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              index: '0x1',
+            },
+            depType: 'code',
+          },
+        ],
+        headerDeps: [],
+        inputs: [
+          {
+            previousOutput: {
+              txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              index: '0x0',
+            },
+            since: '0x0',
+          },
+        ],
+        outputs: [
+          {
+            capacity: '0x48c27395000',
+            lock: {
+              args: [],
+              codeHash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+              hashType: 'data',
+            },
+            type: null,
+          },
+        ],
+        version: '0x0',
+        outputsData: ['0x'],
+        witnesses: [],
+      }
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: '0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3',
+        },
+      })
+      const res = await rpc.sendTransaction(tx, 'passthrough')
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'send_transaction',
+
+        params: [
+          {
+            cell_deps: [
+              {
+                out_point: {
+                  tx_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  index: '0x1',
+                },
+                dep_type: 'code',
+              },
+            ],
+            header_deps: [],
+            inputs: [
+              {
+                previous_output: {
+                  tx_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+                  index: '0x0',
+                },
+                since: '0x0',
+              },
+            ],
+            outputs: [
+              {
+                capacity: '0x48c27395000',
+                lock: {
+                  args: [],
+                  code_hash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  hash_type: 'data',
+                },
+                type: null,
+              },
+            ],
+            version: '0x0',
+            outputs_data: ['0x'],
+            witnesses: [],
+          },
+          'passthrough',
+        ],
+      })
+      expect(res).toEqual('0xa0ef4eb5f4ceeb08a4c8524d84c5da95dce2f608e0ca2ec8091191b0f330c6e3')
+    })
+  })
+
+  describe('ckb-rpc errors', () => {
+    it('throw raw error', async () => {
+      expect(() => rpc.getBlock(0)).toThrow('Hash 0 should be type of string')
+    })
   })
 })

--- a/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
@@ -1121,7 +1121,9 @@
             "block_number": "1",
             "index": "0",
             "tx_hash": "0x41524669872de0ce874f926a9799b6944198571094fe94dc7ffa623a97c4f19f"
-          }
+          },
+          "cellbase": false,
+          "output_data_len": "0x0"
         },
         {
           "cell_output": {
@@ -1136,7 +1138,9 @@
             "block_number": "2",
             "index": "0",
             "tx_hash": "0x46ab01ddbbabef1af701f0843e11c7cfc0ce53f9aa9b554af74cadf8e3257d89"
-          }
+          },
+          "cellbase": true,
+          "output_data_len": "0x0"
         }
       ],
       "expected": [
@@ -1153,7 +1157,9 @@
             "blockNumber": "1",
             "index": "0",
             "txHash": "0x41524669872de0ce874f926a9799b6944198571094fe94dc7ffa623a97c4f19f"
-          }
+          },
+          "cellbase": false,
+          "outputDataLen": "0x0"
         },
         {
           "cellOutput": {
@@ -1169,7 +1175,9 @@
             "blockNumber": "2",
             "index": "0",
             "txHash": "0x46ab01ddbbabef1af701f0843e11c7cfc0ce53f9aa9b554af74cadf8e3257d89"
-          }
+          },
+          "cellbase": true,
+          "outputDataLen": "0x0"
         }
       ]
     }

--- a/packages/ckb-sdk-rpc/src/Base.ts
+++ b/packages/ckb-sdk-rpc/src/Base.ts
@@ -1,193 +1,164 @@
 import paramsFmts from './paramsFormatter'
 import resultFmts from './resultFormatter'
 
-const defaultRPC: CKBComponents.Method[] = [
-  {
-    name: 'getBlockByNumber',
+interface RpcPropertes {
+  [name: string]: Omit<CKBComponents.Method, 'name'>
+}
+
+export const rpcProperties: RpcPropertes = {
+  getBlockByNumber: {
     method: 'get_block_by_number',
     paramsFormatters: [paramsFmts.toNumber],
     resultFormatters: resultFmts.toBlock,
   },
-  {
-    name: 'getBlock',
+  getBlock: {
     method: 'get_block',
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toBlock,
   },
-  {
-    name: 'getTransaction',
+  getTransaction: {
     method: 'get_transaction',
     paramsFormatters: [paramsFmts.toHash, paramsFmts.toNumber, paramsFmts.toNumber],
     resultFormatters: resultFmts.toTransactionWithStatus,
   },
-  {
-    name: 'getBlockHash',
+  getBlockHash: {
     method: 'get_block_hash',
     paramsFormatters: [paramsFmts.toNumber],
   },
-  {
-    name: 'getTipHeader',
+  getTipHeader: {
     method: 'get_tip_header',
     paramsFormatters: [],
     resultFormatters: resultFmts.toHeader,
   },
-  {
-    name: 'getCellsByLockHash',
+  getCellsByLockHash: {
     method: 'get_cells_by_lock_hash',
     paramsFormatters: [paramsFmts.toHash, paramsFmts.toNumber, paramsFmts.toNumber],
     resultFormatters: resultFmts.toCellsIncludingOutPoint,
   },
-  {
-    name: 'getLiveCell',
+  getLiveCell: {
     method: 'get_live_cell',
     paramsFormatters: [paramsFmts.toOutPoint],
     resultFormatters: resultFmts.toLiveCellWithStatus,
   },
-  {
-    name: 'getTipBlockNumber',
+  getTipBlockNumber: {
     method: 'get_tip_block_number',
     paramsFormatters: [],
     resultFormatters: resultFmts.toNumber,
   },
-  {
-    name: 'getBlockchainInfo',
+  getBlockchainInfo: {
     method: 'get_blockchain_info',
     paramsFormatters: [],
     resultFormatters: resultFmts.toBlockchainInfo,
   },
-  {
-    name: 'sendTransaction',
+  sendTransaction: {
     method: 'send_transaction',
     paramsFormatters: [paramsFmts.toRawTransaction, paramsFmts.toOutputsValidator],
     resultFormatters: resultFmts.toHash,
   },
-  {
-    name: 'localNodeInfo',
+  localNodeInfo: {
     method: 'local_node_info',
     paramsFormatters: [],
     resultFormatters: resultFmts.toNodeInfo,
   },
-  {
-    name: 'txPoolInfo',
+  txPoolInfo: {
     method: 'tx_pool_info',
     paramsFormatters: [],
     resultFormatters: resultFmts.toTxPoolInfo,
   },
-  {
-    name: 'getPeers',
+  getPeers: {
     method: 'get_peers',
     paramsFormatters: [],
     resultFormatters: resultFmts.toPeers,
   },
-  {
-    name: 'getPeersState',
+  getPeersState: {
     method: 'get_peers_state',
     paramsFormatters: [],
     resultFormatters: resultFmts.toPeersState,
   },
-  {
-    name: 'getCurrentEpoch',
+  getCurrentEpoch: {
     method: 'get_current_epoch',
     paramsFormatters: [],
     resultFormatters: resultFmts.toEpoch,
   },
-  {
-    name: 'getEpochByNumber',
+  getEpochByNumber: {
     method: 'get_epoch_by_number',
     paramsFormatters: [paramsFmts.toNumber],
     resultFormatters: resultFmts.toEpoch,
   },
-  {
-    name: 'dryRunTransaction',
+  dryRunTransaction: {
     method: 'dry_run_transaction',
     paramsFormatters: [paramsFmts.toRawTransaction],
   },
-  {
-    name: 'deindexLockHash',
+  deindexLockHash: {
     method: 'deindex_lock_hash',
     paramsFormatters: [paramsFmts.toHash],
   },
-  {
-    name: 'getLiveCellsByLockHash',
+  getLiveCellsByLockHash: {
     method: 'get_live_cells_by_lock_hash',
     paramsFormatters: [paramsFmts.toHash, paramsFmts.toPageNumber, paramsFmts.toPageSize, paramsFmts.toReverseOrder],
     resultFormatters: resultFmts.toLiveCellsByLockHash,
   },
-  {
-    name: 'getLockHashIndexStates',
+  getLockHashIndexStates: {
     method: 'get_lock_hash_index_states',
     paramsFormatters: [],
     resultFormatters: resultFmts.toLockHashIndexStates,
   },
-  {
-    name: 'getTransactionsByLockHash',
+  getTransactionsByLockHash: {
     method: 'get_transactions_by_lock_hash',
     paramsFormatters: [paramsFmts.toHash, paramsFmts.toPageNumber, paramsFmts.toPageSize, paramsFmts.toReverseOrder],
     resultFormatters: resultFmts.toTransactionsByLockHash,
   },
-  {
-    name: 'indexLockHash',
+  indexLockHash: {
     method: 'index_lock_hash',
     paramsFormatters: [paramsFmts.toHash, paramsFmts.toOptional(paramsFmts.toNumber)],
     resultFormatters: resultFmts.toLockHashIndexState,
   },
-  {
-    name: 'getBannedAddresses',
+  getBannedAddresses: {
     method: 'get_banned_addresses',
     paramsFormatters: [],
     resultFormatters: resultFmts.toBannedAddresses,
   },
-  {
-    name: 'setBan',
+  setBan: {
     method: 'set_ban',
     paramsFormatters: [],
   },
-  {
-    name: 'getHeader',
+  getHeader: {
     method: 'get_header',
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toHeader,
   },
-  {
-    name: 'getHeaderByNumber',
+  getHeaderByNumber: {
     method: 'get_header_by_number',
     paramsFormatters: [paramsFmts.toNumber],
     resultFormatters: resultFmts.toHeader,
   },
-  {
-    name: 'getCellbaseOutputCapacityDetails',
+  getCellbaseOutputCapacityDetails: {
     method: 'get_cellbase_output_capacity_details',
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toCellbaseOutputCapacityDetails,
   },
-  {
-    name: 'estimateFeeRate',
+  estimateFeeRate: {
     method: 'estimate_fee_rate',
     paramsFormatters: [paramsFmts.toNumber],
     resultFormatters: resultFmts.toFeeRate,
   },
-  {
-    name: 'calculateDaoMaximumWithdraw',
+  calculateDaoMaximumWithdraw: {
     method: 'calculate_dao_maximum_withdraw',
     paramsFormatters: [paramsFmts.toOutPoint, paramsFmts.toHash],
   },
-  {
-    name: 'getCapacityByLockHash',
+  getCapacityByLockHash: {
     method: 'get_capacity_by_lock_hash',
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toCapacityByLockHash,
   },
-  {
-    name: 'getBlockEconomicState',
+  getBlockEconomicState: {
     method: 'get_block_economic_state',
     paramsFormatters: [paramsFmts.toHash],
     resultFormatters: resultFmts.toBlockEconomicState,
   },
-]
+}
 
-export class DefaultRPC {
-  protected defaultMethods = defaultRPC
-
+export interface Base {
   /**
    * @method getBlockByNumber
    * @memberof DefaultRPC
@@ -195,7 +166,7 @@ export class DefaultRPC {
    * @param {string} number - the block number of the target block
    * @returns {Promise<object>} block object
    */
-  public getBlockByNumber!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Block>
+  getBlockByNumber: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Block>
 
   /**
    * @method getBlockByNumber
@@ -204,7 +175,7 @@ export class DefaultRPC {
    * @param {string} hash - the block hash of the target block
    * @returns {Promise<object>} block object
    */
-  public getBlock!: (hash: CKBComponents.Hash) => Promise<CKBComponents.Block>
+  getBlock: (hash: CKBComponents.Hash) => Promise<CKBComponents.Block>
 
   /**
    * @method getTransaction
@@ -213,7 +184,7 @@ export class DefaultRPC {
    * @param {string} hash - the transaction hash of the target transaction
    * @return {Promise<object>} transaction object with transaction status
    */
-  public getTransaction!: (hash: CKBComponents.Hash) => Promise<CKBComponents.TransactionWithStatus>
+  getTransaction: (hash: CKBComponents.Hash) => Promise<CKBComponents.TransactionWithStatus>
 
   /**
    * @method getBlockHash
@@ -222,7 +193,7 @@ export class DefaultRPC {
    * @param {string} hash - block hash
    * @return {Promise<string>} block hash
    */
-  public getBlockHash!: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Hash>
+  getBlockHash: (number: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.Hash>
 
   /**
    * @method getTipHeader
@@ -230,7 +201,7 @@ export class DefaultRPC {
    * @description rpc to get the tip header of the longeest blockchain
    * @return {Promise<object>} block header
    */
-  public getTipHeader!: () => Promise<CKBComponents.BlockHeader>
+  getTipHeader: () => Promise<CKBComponents.BlockHeader>
 
   /**
    * @method getCellsByLockHash
@@ -242,7 +213,7 @@ export class DefaultRPC {
    * @param {string} to - the end block number
    * @return {object[]} array of objects including lock script, capacity, outPoint
    */
-  public getCellsByLockHash!: (
+  getCellsByLockHash: (
     hash: CKBComponents.Hash256,
     from: CKBComponents.BlockNumber | bigint,
     to: CKBComponents.BlockNumber | bigint,
@@ -257,7 +228,7 @@ export class DefaultRPC {
    * @param {boolean} withData - set withData to true to return cell data and data hash if the cell is live
    * @return {Promise<object>} liveCellWithStatus
    */
-  public getLiveCell!: (
+  getLiveCell: (
     outPoint: CKBComponents.OutPoint,
     withData: boolean,
   ) => Promise<{
@@ -271,7 +242,7 @@ export class DefaultRPC {
    * @description rpc to get the number of blocks in the longest blockchain
    * @return {Promise<string>} block number
    */
-  public getTipBlockNumber!: () => Promise<CKBComponents.BlockNumber>
+  getTipBlockNumber: () => Promise<CKBComponents.BlockNumber>
 
   /**
    * @method sendTransaction
@@ -284,7 +255,7 @@ export class DefaultRPC {
    *                                  null and passthrough mean skipping outputs validation
    * @return {Promise<string>} transaction hash
    */
-  public sendTransaction!: (
+  sendTransaction: (
     tx: CKBComponents.RawTransaction,
     outputsValidator?: CKBComponents.OutputsValidator,
   ) => Promise<CKBComponents.Hash>
@@ -296,7 +267,7 @@ export class DefaultRPC {
    * @return {Promise<object>} blockchain info, including chain name, difficulty, epoch number,
    *                           is_intial_block_download, median time, warnings
    */
-  public getBlockchainInfo!: () => Promise<CKBComponents.BlockchainInfo>
+  getBlockchainInfo: () => Promise<CKBComponents.BlockchainInfo>
 
   /**
    * @method localNodeInfo
@@ -304,7 +275,7 @@ export class DefaultRPC {
    * @description rpc to get the local node information
    * @return {Promise<object>} node info, including addresses, is_outbound, node id, and version
    */
-  public localNodeInfo!: () => Promise<CKBComponents.NodeInfo>
+  localNodeInfo: () => Promise<CKBComponents.NodeInfo>
 
   /**
    * @method txPoolInfo
@@ -313,7 +284,7 @@ export class DefaultRPC {
    * @return {Promise<object>} info of transaction pool, including last_txs_updated_at, number of orphan,
    *                           number of pending, number of proposed
    */
-  public txPoolInfo!: () => Promise<CKBComponents.TxPoolInfo>
+  txPoolInfo: () => Promise<CKBComponents.TxPoolInfo>
 
   /**
    * @method getPeers
@@ -321,7 +292,7 @@ export class DefaultRPC {
    * @description rpc to get connected peers info
    * @return {Promise<object[]>} peers' node info
    */
-  public getPeers!: () => Promise<CKBComponents.NodeInfo[]>
+  getPeers: () => Promise<CKBComponents.NodeInfo[]>
 
   /**
    * @method getPeersState
@@ -329,7 +300,7 @@ export class DefaultRPC {
    * @description rpc to get state info of peers
    * @return {Promise<object[]>} peers' state info, including blocks_in_flight, last_updated, peer number
    */
-  public getPeersState!: () => Promise<CKBComponents.PeersState>
+  getPeersState: () => Promise<CKBComponents.PeersState>
 
   /**
    * @method getCurrentEpoch
@@ -338,7 +309,7 @@ export class DefaultRPC {
    * @return {Promise<object>} epoch info, including block reward, difficulty, last_block_hash_in_previous_epoch,
    *                           length, number, remainder reward, start number
    */
-  public getCurrentEpoch!: () => Promise<CKBComponents.Epoch>
+  getCurrentEpoch: () => Promise<CKBComponents.Epoch>
 
   /**
    * @method getEpochByNumber
@@ -346,7 +317,7 @@ export class DefaultRPC {
    * @description rpc to get the epoch info by its number
    * @return {Promise<object>} epoch info
    */
-  public getEpochByNumber!: (epoch: string | bigint) => Promise<CKBComponents.Epoch>
+  getEpochByNumber: (epoch: string | bigint) => Promise<CKBComponents.Epoch>
 
   /**
    * @method dryRunTransaction
@@ -356,7 +327,7 @@ export class DefaultRPC {
    * @param {object} rawTrasnaction - the raw transaction whose cycles is going to be calculated
    * @return {Promise<object>} dry run result, including cycles the transaction used.
    */
-  public dryRunTransaction!: (tx: CKBComponents.RawTransaction) => Promise<CKBComponents.RunDryResult>
+  dryRunTransaction: (tx: CKBComponents.RawTransaction) => Promise<CKBComponents.RunDryResult>
 
   /**
    * @method deindexLockHash
@@ -366,7 +337,7 @@ export class DefaultRPC {
    * @param {string} lockHash
    * @retrun {Promise<null}
    */
-  public deindexLockHash!: (lockHash: CKBComponents.Hash256) => Promise<null>
+  deindexLockHash: (lockHash: CKBComponents.Hash256) => Promise<null>
 
   /**
    * @method getLiveCellsByLockHash
@@ -379,7 +350,7 @@ export class DefaultRPC {
    *                                  an optional parameter, default to be false
    * @return {Promise<object[]>}
    */
-  public getLiveCellsByLockHash!: (
+  getLiveCellsByLockHash: (
     lockHash: CKBComponents.Hash256,
     pageNumber: string | bigint,
     pageSize: string | bigint,
@@ -392,7 +363,7 @@ export class DefaultRPC {
    * @description get lock hash index states
    * @retrun {Promise<object[]>}
    */
-  public getLockHashIndexStates!: () => Promise<CKBComponents.LockHashIndexStates>
+  getLockHashIndexStates: () => Promise<CKBComponents.LockHashIndexStates>
 
   /**
    * @method getTransactionsByLockHash
@@ -405,7 +376,7 @@ export class DefaultRPC {
    * @param {boolean} [reverseOrder], return the transactions collection in reverse order,
    *                                  an optional parameter, default to be false
    */
-  public getTransactionsByLockHash!: (
+  getTransactionsByLockHash: (
     lockHash: CKBComponents.Hash256,
     pageNumber: string | bigint,
     pageSize: string | bigint,
@@ -420,7 +391,7 @@ export class DefaultRPC {
    * @param {string} [indexFrom], the starting block number(exclusive), an optional parameter,
    *                              null means starting from the tip and 0 means starting from genesis
    */
-  public indexLockHash!: (
+  indexLockHash: (
     lockHash: CKBComponents.Hash,
     indexFrom?: CKBComponents.BlockNumber,
   ) => Promise<CKBComponents.LockHashIndexState>
@@ -430,7 +401,7 @@ export class DefaultRPC {
    * @memberof DefaultRPC
    * @description Returns all banned IPs/Subnets
    */
-  public getBannedAddresses!: () => Promise<CKBComponents.BannedAddresses>
+  getBannedAddresses: () => Promise<CKBComponents.BannedAddresses>
   /**
    * @method setBan
    * @memberof DefaultRPC
@@ -445,7 +416,7 @@ export class DefaultRPC {
    * @param {[string]} reason, Ban reason, optional parameter
    */
 
-  public setBan!: (
+  setBan: (
     address: string,
     command: 'insert' | 'delete',
     banTime: string | null,
@@ -459,7 +430,7 @@ export class DefaultRPC {
    * @description Returns the information about a block header by hash.
    * @params {string} block hash
    */
-  public getHeader!: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockHeader>
+  getHeader: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockHeader>
 
   /**
    * @method getHeaderByNumber
@@ -467,7 +438,7 @@ export class DefaultRPC {
    * @description Returns the information about a block header by block number
    * @params {string} block number
    */
-  public getHeaderByNumber!: (blockNumber: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.BlockHeader>
+  getHeaderByNumber: (blockNumber: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.BlockHeader>
 
   /**
    * @method getCellbaseOutputCapacityDetails
@@ -476,7 +447,7 @@ export class DefaultRPC {
    *              a block N - 1 - ProposalWindow.farthest, where this block's height is N.
    * @param {string} blockHash
    */
-  public getCellbaseOutputCapacityDetails!: (
+  getCellbaseOutputCapacityDetails: (
     blockHash: CKBComponents.Hash,
   ) => Promise<CKBComponents.CellbaseOutputCapacityDetails>
 
@@ -487,14 +458,14 @@ export class DefaultRPC {
    * @param {string} expectedBlocks, the expected range in blocks therein transactions will be committed
    *                                 the range is [3, 1000]
    */
-  public estimateFeeRate!: (expectedBlocks: CKBComponents.BlockNumber) => Promise<CKBComponents.FeeRate>
+  estimateFeeRate: (expectedBlocks: CKBComponents.BlockNumber) => Promise<CKBComponents.FeeRate>
 
-  public calculateDaoMaximumWithdraw!: (
+  calculateDaoMaximumWithdraw: (
     outPoint: CKBComponents.OutPoint,
     withdrawBlockHash: CKBComponents.Hash256,
   ) => Promise<string>
 
-  public getCapacityByLockHash!: (lockHash: CKBComponents.Hash) => Promise<CKBComponents.CapacityByLockHash>
+  getCapacityByLockHash: (lockHash: CKBComponents.Hash) => Promise<CKBComponents.CapacityByLockHash>
 
   /**
    * @method getBlockEconomicState
@@ -503,7 +474,11 @@ export class DefaultRPC {
    * @param {string} blockHash
    * @returns {Promise<BlockEconomicState>}
    */
-  public getBlockEconomicState!: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockEconomicState>
+  getBlockEconomicState: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockEconomicState>
 }
 
-export default DefaultRPC
+export class Base {
+  protected rpcProperties = rpcProperties
+}
+
+export default Base

--- a/packages/ckb-sdk-rpc/src/index.ts
+++ b/packages/ckb-sdk-rpc/src/index.ts
@@ -1,12 +1,12 @@
 /// <reference types="../types/rpc" />
 
-import DefaultRPC from './defaultRPC'
+import Base from './Base'
 import Method from './method'
 
 import paramsFormatter from './paramsFormatter'
 import resultFormatter from './resultFormatter'
 
-class CKBRPC extends DefaultRPC {
+class CKBRPC extends Base {
   public node: CKBComponents.Node = {
     url: '',
   }
@@ -22,7 +22,9 @@ class CKBRPC extends DefaultRPC {
     this.setNode({
       url,
     })
-    this.defaultMethods.map(this.addMethod)
+    Object.keys(this.rpcProperties).forEach(name => {
+      this.addMethod({ name, ...this.rpcProperties[name] })
+    })
   }
 
   public setNode(node: CKBComponents.Node): CKBComponents.Node {

--- a/packages/ckb-sdk-rpc/src/resultFormatter.ts
+++ b/packages/ckb-sdk-rpc/src/resultFormatter.ts
@@ -253,6 +253,8 @@ const formatter = {
     return cells.map(cell => ({
       cellOutput: formatter.toCell(cell.cell_output),
       createdBy: formatter.toTransactionPoint(cell.created_by),
+      cellbase: cell.cellbase,
+      outputDataLen: cell.output_data_len,
     }))
   },
   toLockHashIndexState: (index: RPC.LockHashIndexState): CKBComponents.LockHashIndexState => {

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -122,6 +122,8 @@ declare module RPC {
   export interface LiveCellByLockHash {
     cell_output: CellOutput
     created_by: TransactionPoint
+    cellbase: boolean
+    output_data_len: string
   }
   export type LiveCellsByLockHash = LiveCellByLockHash[]
 
@@ -223,13 +225,13 @@ declare module RPC {
   }
 
   export interface FeeRate {
-    fee_rate: Number
+    fee_rate: string
   }
 
   export interface CapacityByLockHash {
     block_number: BlockNumber
     capacity: Capacity
-    cells_count: Number
+    cells_count: string
   }
 
   export interface BlockEconomicState {

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -286,6 +286,8 @@ declare namespace CKBComponents {
   export interface LiveCellByLockHash {
     cellOutput: CellOutput
     createdBy: TransactionPoint
+    cellbase: boolean
+    outputDataLen: string
   }
 
   export type LiveCellsByLockHash = LiveCellByLockHash[]
@@ -371,7 +373,7 @@ declare namespace CKBComponents {
   }
 
   export interface FeeRate {
-    feeRate: Number
+    feeRate: string
   }
 
   export type BytesOpt = Bytes | undefined
@@ -389,7 +391,7 @@ declare namespace CKBComponents {
   export interface CapacityByLockHash {
     blockNumber: BlockNumber
     capacity: Capacity
-    cellsCount: Number
+    cellsCount: string
   }
 
   export interface BlockEconomicState {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,6 +7093,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"


### PR DESCRIPTION
1. fix the return type of `rpc.getLiveCellsByLockHash` by adding two missing fields of `cellbase` and `outputDataLen`;
2. refactor the default rpc list to make it clear;
3. add two npm scripts to build/clean libs;