### PR TITLE
fix(utils): rename the arg field in params of utils#fullPayloadToAddr…

### DIFF
--- a/packages/ckb-sdk-utils/__tests__/utils/index.test.js
+++ b/packages/ckb-sdk-utils/__tests__/utils/index.test.js
@@ -100,7 +100,7 @@ describe('blake', () => {
 })
 
 describe('bech32', () => {
-  bech32Fixtures.bech32.valid.forEach((f) => {
+  bech32Fixtures.bech32.valid.forEach(f => {
     it(`fromWords/toWords ${f.hex}`, () => {
       if (f.hex) {
         const words = bech32.toWords(Buffer.from(f.hex, 'hex'))
@@ -159,7 +159,7 @@ describe('scriptToHash', () => {
       scriptHash: '0xd39f84d4702f53cf8625da4411be1640b961715cb36816501798fedb70b6e0fb',
     },
   }
-  test.each(Object.keys(fixtures))('%s', (fixtureName) => {
+  test.each(Object.keys(fixtures))('%s', fixtureName => {
     const fixture = fixtures[fixtureName]
     const scriptHash = scriptToHash(fixture.script)
     expect(scriptHash).toBe(fixture.scriptHash)
@@ -219,7 +219,7 @@ describe('address', () => {
   it('fullPayloadToAddress with hash type of Data', () => {
     const fixture = {
       params: {
-        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
         type: AddressType.DataCodeHash,
         prefix: 'ckt',
         codeHash: '0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176',
@@ -233,7 +233,7 @@ describe('address', () => {
   it('fullPayloadToAddress with hash type of Type', () => {
     const fixture = {
       params: {
-        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
         type: AddressType.TypeCodeHash,
         prefix: 'ckt',
         codeHash: '0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2',
@@ -247,7 +247,7 @@ describe('address', () => {
   it('fullPayloadToAddress with default params of type = AddressType.DataCodeHash and prefix = ckt', () => {
     const fixture = {
       params: {
-        arg: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
         codeHash: '0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176',
       },
       expected: 'ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac',
@@ -322,7 +322,7 @@ describe('address', () => {
       address: 'ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83',
     },
   }
-  test.each(Object.keys(pubkeyToAddressFixtures))('%s', (caseName) => {
+  test.each(Object.keys(pubkeyToAddressFixtures))('%s', caseName => {
     const fixture = pubkeyToAddressFixtures[caseName]
     const address = pubkeyToAddress(hexToBytes(fixture.pubkey), fixture.config)
     expect(address).toBe(fixture.address)

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -39,7 +39,7 @@ export const defaultAddressOptions = {
 export const toAddressPayload = (
   args: string | Uint8Array,
   type: AddressType = AddressType.HashIdx,
-  codeHashOrCodeHashIndex: CodeHashIndex | CKBComponents.Hash256 = '0x00'
+  codeHashOrCodeHashIndex: CodeHashIndex | CKBComponents.Hash256 = '0x00',
 ): Uint8Array => {
   if (typeof args === 'string') {
     if (!args.startsWith('0x')) {
@@ -53,41 +53,41 @@ export const toAddressPayload = (
 /**
  * @name bech32Address
  * @description generate the address by bech32 algorithm
- * @param arg, used as the identifier of an address, usually the public key hash is used.
+ * @param args, used as the identifier of an address, usually the public key hash is used.
  * @param {string} prefix, the prefix precedes the address.
  * @param {string} type, used to indicate which format is adopted to compose the address.
  * @param {string} codeHashOrCodeHashIndex, the referenced code hash or code hash index the address binds to.
  */
 export const bech32Address = (
-  arg: Uint8Array | string,
+  args: Uint8Array | string,
   {
     prefix = AddressPrefix.Testnet,
     type = AddressType.HashIdx,
     codeHashOrCodeHashIndex = '0x00',
-  }: AddressOptions = defaultAddressOptions
-) => bech32.encode(prefix, bech32.toWords(toAddressPayload(arg, type, codeHashOrCodeHashIndex)))
+  }: AddressOptions = defaultAddressOptions,
+) => bech32.encode(prefix, bech32.toWords(toAddressPayload(args, type, codeHashOrCodeHashIndex)))
 
 /**
  * @name fullPayloadToAddress
  * @description generate the address with payload in full version format.
- * @param {string} arg, used as the identifier of an address.
+ * @param {string} args, used as the identifier of an address.
  * @param {string} prefix, the prefix precedes the address.
  * @param {string} type, used to indicate which format the address conforms to,
  *                       with hash type of Data or with hash type of Type.
  * @param {string} codeHash, the code hash used in the full version payload.
  */
 export const fullPayloadToAddress = ({
-  arg,
+  args,
   prefix = AddressPrefix.Testnet,
   type = AddressType.DataCodeHash,
   codeHash,
 }: {
-  arg: string
+  args: string
   prefix: AddressPrefix
   type: AddressType.DataCodeHash | AddressType.TypeCodeHash
   codeHash: CKBComponents.Hash256
 }) =>
-  bech32Address(arg, {
+  bech32Address(args, {
     prefix,
     type,
     codeHashOrCodeHashIndex: codeHash,
@@ -99,7 +99,7 @@ export const pubkeyToAddress = (
     prefix = AddressPrefix.Testnet,
     type = AddressType.HashIdx,
     codeHashOrCodeHashIndex = '0x00' as CodeHashIndex,
-  }: AddressOptions = defaultAddressOptions
+  }: AddressOptions = defaultAddressOptions,
 ) => {
   const publicKeyHash = blake160(pubkey)
   return bech32Address(publicKeyHash, {


### PR DESCRIPTION
…ess to args

BREAKING CHANGE: The arg field in params of utils#fullPayloadToAddress is renamed to args