### PR TITLE
feat(core): parse scripts from addresses on generating transactions

### DIFF
--- a/packages/ckb-sdk-core/__tests__/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/fixtures.json
@@ -6,7 +6,8 @@
       "outPoint": {
         "txHash": "0x84dcb061adebff4ef93d57c975ba9058a9be939d79ea12ee68003f6492448890",
         "index": "0x0"
-      }
+      },
+      "depType": "depGroup"
     },
     "daoDep": {
       "hashType": "type",
@@ -15,7 +16,8 @@
       "outPoint": {
         "txHash": "0x15fb8111fc78fa36da6af96c45ac4714cc9a33974fdae13cc524b29e1a488c7f",
         "index": "0x2"
-      }
+      },
+      "depType": "depGroup"
     }
   },
   "signTransaction": {
@@ -360,10 +362,10 @@
     }
   },
   "generateRawTransaction": {
-    "testnet": {
+    "simple": {
       "params": {
         "fromAddress": "ckt1qyqw975zuu9svtyxgjuq44lv7mspte0n2tmqa703cd",
-        "toAddress": "ckt1qyqdm0tlp845spzscxc76tyxjcjgm6gudqpq4h77wx",
+        "toAddress": "ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac",
         "capacity": 783602013670,
         "safeMode": true,
         "isMainnet": false,
@@ -525,7 +527,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -587,8 +590,274 @@
           {
             "capacity": "0xb67251d5e6",
             "lock": {
-              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+              "codeHash": "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176",
+              "hashType": "data"
+            }
+          },
+          {
+            "capacity": "0x88cb4e12e",
+            "lock": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          }
+        ],
+        "outputsData": ["0x", "0x"],
+        "version": "0x0",
+        "witnesses": []
+      }
+    },
+    "complex": {
+      "params": {
+        "fromAddresses": ["ckt1qyqw975zuu9svtyxgjuq44lv7mspte0n2tmqa703cd"],
+        "receivePairs": [
+          {
+            "address": "ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac",
+            "capacity": 783602013670,
+            "type": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          }
+        ],
+        "safeMode": true,
+        "isMainnet": false,
+        "cells": [
+          [
+            "0x641238cd95b9f5e6224da1963a0bcaa2e972dc87e56eb1ded9a35dcebbc37ff4",
+            [
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x0"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x1"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x2"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x3"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x4"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x5"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x6"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x7"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x8"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              },
+              {
+                "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+                "lock": {
+                  "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                  "hashType": "type",
+                  "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+                },
+                "outPoint": {
+                  "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+                  "index": "0x9"
+                },
+                "capacity": "0x1fd52bc92e",
+                "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "status": "live"
+              }
+            ]
+          ]
+        ],
+        "deps": {
+          "hashType": "type",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "outPoint": {
+            "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
+            "index": "0x0"
+          },
+          "depType": "depGroup"
+        }
+      },
+      "expected": {
+        "cellDeps": [
+          {
+            "depType": "depGroup",
+            "outPoint": {
+              "index": "0x0",
+              "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091"
+            }
+          }
+        ],
+        "headerDeps": [],
+        "inputs": [
+          {
+            "previousOutput": {
+              "index": "0x1",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x2",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x3",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x4",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x5",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x6",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "0xb67251d5e6",
+            "lock": {
+              "args": "0x36c329ed630d6ce750712a477543672adab57f4c",
+              "codeHash": "0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176",
+              "hashType": "data"
+            },
+            "type": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           },
@@ -596,7 +865,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }

--- a/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
@@ -1026,7 +1026,7 @@
         "witnesses": []
       }
     },
-    "multi-inputs": {
+    "multi inputs": {
       "params": {
         "inputScripts": [
           {
@@ -1177,6 +1177,279 @@
             "capacity": "0x17780d860",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          }
+        ],
+        "outputsData": ["0x", "0x"],
+        "version": "0x0",
+        "witnesses": []
+      }
+    },
+    "multi cell deps": {
+      "params": {
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "capacity": 783602000000,
+        "fee": 13670,
+        "safeMode": true,
+        "cells": [
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x0"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x1"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x2"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x3"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x4"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x5"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x6"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x7"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x8"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          },
+          {
+            "blockHash": "0x355cd43b6b517be40ce69278b7c6d2017546e2d46557d59e31adff20646c845e",
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x9"
+            },
+            "capacity": "0x1fd52bc92e",
+            "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "status": "live"
+          }
+        ],
+        "deps": [
+          {
+            "hashType": "type",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "outPoint": {
+              "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
+              "index": "0x0"
+            },
+            "depType": "depGroup"
+          },
+          {
+            "hashType": "type",
+            "codeHash": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "outPoint": {
+              "txHash": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+              "index": "0x1"
+            },
+            "depType": "code"
+          }
+        ]
+      },
+      "expected": {
+        "cellDeps": [
+          {
+            "depType": "depGroup",
+            "outPoint": {
+              "index": "0x0",
+              "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091"
+            }
+          },
+          {
+            "depType": "code",
+            "outPoint": {
+              "txHash": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+              "index": "0x1"
+            }
+          }
+        ],
+        "headerDeps": [],
+        "inputs": [
+          {
+            "previousOutput": {
+              "index": "0x1",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x2",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x3",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x4",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x5",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x6",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "0xb67251a080",
+            "lock": {
+              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            }
+          },
+          {
+            "capacity": "0x88cb4e12e",
+            "lock": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
               "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }

--- a/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
@@ -2,8 +2,16 @@
   "generateRawTransaction": {
     "safeMode = true": {
       "params": {
-        "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-        "toPublicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
         "capacity": 783602000000,
         "fee": 13670,
         "safeMode": true,
@@ -165,7 +173,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -236,7 +245,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }
@@ -248,8 +257,16 @@
     },
     "safeMode = true by default": {
       "params": {
-        "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-        "toPublicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
         "capacity": 783602000000,
         "fee": 13670,
         "cells": [
@@ -410,7 +427,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -481,7 +499,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }
@@ -493,8 +511,16 @@
     },
     "safeMode = false": {
       "params": {
-        "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-        "toPublicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
         "capacity": 783602000000,
         "fee": 13670,
         "safeMode": false,
@@ -656,7 +682,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -727,7 +754,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }
@@ -739,8 +766,16 @@
     },
     "more than one input for change": {
       "params": {
-        "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-        "toPublicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
         "capacity": 819602000000,
         "fee": 13670,
         "safeMode": true,
@@ -902,7 +937,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -980,7 +1016,7 @@
             "capacity": "0x20001c425c",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }
@@ -992,14 +1028,31 @@
     },
     "multi-inputs": {
       "params": {
-        "fromPublicKeyHashes": [
-          "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-          "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f5"
+        "inputScripts": [
+          {
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          },
+          {
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f5",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          }
         ],
         "changePublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0",
-        "receivePairs": [
+        "outputs": [
           {
-            "publicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+            "lock": {
+              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            },
+            "type": {
+              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            },
             "capacity": 12000000000
           }
         ],
@@ -1068,7 +1121,8 @@
           "outPoint": {
             "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
             "index": "0x0"
-          }
+          },
+          "depType": "depGroup"
         }
       },
       "expected": {
@@ -1112,13 +1166,18 @@
               "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
               "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
+            },
+            "type": {
+              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
             }
           },
           {
             "capacity": "0x17780d860",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0",
-              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
               "hashType": "type"
             }
           }
@@ -1130,8 +1189,16 @@
     },
     "should throw an error when dep is missing": {
       "params": {
-        "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-        "toPublicKeyHash": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+          "hashType": "type"
+        },
         "capacity": 783602000000,
         "fee": 13670,
         "safeMode": true,
@@ -1191,8 +1258,16 @@
     "simpleParams": {
       "params": [
         {
-          "fromPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-          "toPublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "inputScript": {
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          },
+          "outputScript": {
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          },
           "capacity": "0x111",
           "cells": [
             {
@@ -1201,17 +1276,23 @@
               "outPoint": { "txHash": "0x", "index": "0x0" }
             }
           ]
-        },
-        {
-          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-          "hashType": "type"
         }
       ],
       "expected": {
-        "fromPkhes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
-        "toPkhAndCapacityPairs": [
+        "inputScripts": [
           {
-            "publicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          }
+        ],
+        "outputs": [
+          {
+            "lock": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            },
             "capacity": "0x111"
           }
         ],
@@ -1226,13 +1307,23 @@
     "complexParams": {
       "params": [
         {
-          "receivePairs": [
+          "inputScripts": [
             {
-              "publicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            }
+          ],
+          "outputs": [
+            {
+              "lock": {
+                "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+                "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                "hashType": "type"
+              },
               "capacity": "0x111"
             }
           ],
-          "fromPublicKeyHashes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
           "cells": [
             [
               "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
@@ -1244,17 +1335,23 @@
               [{ "capacity": "0x222", "dataHash": "0x", "outPoint": { "txHash": "0x", "index": "0x0" } }]
             ]
           ]
-        },
-        {
-          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-          "hashType": "type"
         }
       ],
       "expected": {
-        "fromPkhes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
-        "toPkhAndCapacityPairs": [
+        "inputScripts": [
           {
-            "publicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          }
+        ],
+        "outputs": [
+          {
+            "lock": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            },
             "capacity": "0x111"
           }
         ],
@@ -1275,23 +1372,33 @@
     "should return outputs": {
       "params": [
         {
-          "toPkhAndCapacityPairs": [
+          "outputs": [
             {
-              "publicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "lock": {
+                "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+                "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                "hashType": "type"
+              },
+              "type": {
+                "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+                "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+                "hashType": "type"
+              },
               "capacity": 6200000000
             }
           ],
-          "minCapacity": 6100000000,
-          "scriptBase": {
-            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-            "hashType": "type"
-          }
+          "minCapacity": 6100000000
         }
       ],
       "expected": [
         {
           "capacity": 6200000000,
           "lock": {
+            "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+            "hashType": "type"
+          },
+          "type": {
             "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
             "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
             "hashType": "type"
@@ -1302,17 +1409,17 @@
     "should throw an error when capacity is too small": {
       "params": [
         {
-          "toPkhAndCapacityPairs": [
+          "outputs": [
             {
-              "publicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "lock": {
+                "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+                "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                "hashType": "type"
+              },
               "capacity": 6000000000
             }
           ],
-          "minCapacity": 6100000000,
-          "scriptBase": {
-            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-            "hashType": "type"
-          }
+          "minCapacity": 6100000000
         }
       ],
       "exception": "Capacity should be at least 6100000000 shannon"
@@ -1322,16 +1429,18 @@
     "should pass when capacity is enough": {
       "params": [
         {
-          "fromPkhes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
-          "scriptBase": {
-            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-            "hashType": "type"
-          },
+          "inputScripts": [
+            {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          ],
           "safeMode": false,
           "costCapacity": 12200000000,
           "unspentCellsMap": [
             [
-              "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
+              "0x641238cd95b9f5e6224da1963a0bcaa2e972dc87e56eb1ded9a35dcebbc37ff4",
               [
                 {
                   "capacity": "0x16b969d00",
@@ -1376,16 +1485,18 @@
     "non-plain cells should be skipped when safeMode = true": {
       "params": [
         {
-          "fromPkhes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
-          "scriptBase": {
-            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-            "hashType": "type"
-          },
+          "inputScripts": [
+            {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          ],
           "safeMode": true,
           "costCapacity": 12200000000,
           "unspentCellsMap": [
             [
-              "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
+              "0x641238cd95b9f5e6224da1963a0bcaa2e972dc87e56eb1ded9a35dcebbc37ff4",
               [
                 {
                   "capacity": "0x16b969d00",
@@ -1430,16 +1541,18 @@
     "should throw an error when capacity is not enough": {
       "params": [
         {
-          "fromPkhes": ["0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"],
-          "scriptBase": {
-            "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
-            "hashType": "type"
-          },
+          "inputScripts": [
+            {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          ],
           "safeMode": false,
           "costCapacity": 12200000000,
           "unspentCellsMap": [
             [
-              "0x0fec94c611533c9588c8ddfed557b9024f4431a65ace4b1e7106388ddd5dd87b",
+              "0x641238cd95b9f5e6224da1963a0bcaa2e972dc87e56eb1ded9a35dcebbc37ff4",
               [{ "capacity": "0x16b969d00", "dataHash": "0x", "outPoint": { "txHash": "0x", "index": "0x0" } }]
             ]
           ]

--- a/packages/ckb-sdk-core/__tests__/generateRawTransaction/index.test.js
+++ b/packages/ckb-sdk-core/__tests__/generateRawTransaction/index.test.js
@@ -19,12 +19,12 @@ describe('Test generate raw transaction', () => {
       expect.assertions(1)
       try {
         let fmtParams = params
-        if ('fromPublicKeyHash' in params) {
+        if ('inputScript' in params) {
           fmtParams = { ...params, capacity: BigInt(params.capacity), fee: BigInt(params.fee || 0) }
         } else {
           fmtParams = {
             ...params,
-            receivePairs: params.receivePairs.map(pair => ({ ...pair, capacity: BigInt(pair.capacity) })),
+            outputs: params.outputs.map(output => ({ ...output, capacity: BigInt(output.capacity) })),
             cells: new Map(params.cells),
             fee: BigInt(params.fee || 0),
           }

--- a/packages/ckb-sdk-core/__tests__/index.test.js
+++ b/packages/ckb-sdk-core/__tests__/index.test.js
@@ -122,7 +122,7 @@ describe('ckb', () => {
     })
   })
 
-  describe('generate raw transactin', () => {
+  describe('generate raw transaction', () => {
     const fixtureTable = Object.entries(
       fixtures.generateRawTransaction,
     ).map(([title, { params, expected, exception }]) => [title, params, expected, exception])
@@ -130,11 +130,18 @@ describe('ckb', () => {
     test.each(fixtureTable)('%s', (_title, params, expected, exception) => {
       expect.assertions(1)
       try {
-        const rawTransaction = ckb.generateRawTransaction({
-          ...params,
-          capacity: BigInt(params.capacity),
-          fee: BigInt(params.fee || 0),
-        })
+        let fmtParams = params
+        if ('fromAddress' in params) {
+          fmtParams = { ...params, capacity: BigInt(params.capacity), fee: BigInt(params.fee || 0) }
+        } else {
+          fmtParams = {
+            ...params,
+            receivePairs: params.receivePairs.map(pair => ({ ...pair, capacity: BigInt(pair.capacity) })),
+            cells: new Map(params.cells),
+            fee: BigInt(params.fee || 0),
+          }
+        }
+        const rawTransaction = ckb.generateRawTransaction(fmtParams)
         expect(rawTransaction).toEqual(expected)
       } catch (err) {
         expect(err).toEqual(new Error(exception))

--- a/packages/ckb-sdk-core/types/global.d.ts
+++ b/packages/ckb-sdk-core/types/global.d.ts
@@ -3,6 +3,7 @@ interface DepCellInfo {
   codeHash: CKBComponents.Hash256
   typeHash?: CKBComponents.Hash256
   outPoint: CKBComponents.OutPoint
+  depType: CKBComponents.DepType
 }
 
 interface CachedCell extends CKBComponents.CellIncludingOutPoint {
@@ -41,22 +42,26 @@ declare namespace RawTransactionParams {
   interface Base {
     fee?: Capacity
     safeMode: boolean
-    deps: DepCellInfo
+    deps: DepCellInfo | DepCellInfo[]
     capacityThreshold?: Capacity
     changeThreshold?: Capacity
     changePublicKeyHash?: PublicKeyHash
   }
 
   interface Simple extends Base {
-    fromPublicKeyHash: PublicKeyHash
-    toPublicKeyHash: PublicKeyHash
+    inputScript: CKBComponents.Script
+    outputScript: CKBComponents.Script
     capacity: Capacity
     cells?: Cell[]
   }
 
+  interface Output extends CKBComponents.CellOutput {
+    capacity: string | bigint
+  }
+
   interface Complex extends Base {
-    fromPublicKeyHashes: PublicKeyHash[]
-    receivePairs: { publicKeyHash: PublicKeyHash; capacity: Capacity }[]
+    inputScripts: CKBComponents.Script[]
+    outputs: Output[]
     cells?: Map<LockHash, Cell[]>
   }
 }


### PR DESCRIPTION
This commit enables parsing scripts from addresses on generating a transaction, instead of using the
default secp256k1/blake160 script.

But the lock script in change output is fixed to the default secp256k1/blake160 script.

FWIW, the internal interface `generateRawTransaction` in core/generateRawTransaction is changed to accept scripts instead of public key hash.