### PR TITLE
fix(utils):  fix IOS 11 is not fully compatible with blake2b-wasm

### DIFF
--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-types": "0.36.0",
+    "blake2b": "^2.1.3",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.3",
     "jsbi": "3.1.3",

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -32,11 +32,12 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-types": "0.36.0",
-    "blake2b": "^2.1.3",
+    "blake2b": "2.1.3",
     "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.3",
     "jsbi": "3.1.3",
-    "tslib": "2.0.1"
+    "tslib": "2.0.1",
+    "window": "4.2.7"
   },
   "devDependencies": {
     "@types/bitcoinjs-lib": "5.0.0",

--- a/packages/ckb-sdk-utils/src/crypto/blake2b.ts
+++ b/packages/ckb-sdk-utils/src/crypto/blake2b.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
-const b2wasm = require('blake2b-wasm')
 const blake2bjs = require('blake2b')
+const b2wasm = require('blake2b-wasm')
+const Window = require('window')
+
 const {
   OutLenTooSmallException,
   OutLenTooLargeException,
@@ -375,17 +377,18 @@ export const blake2b = (
   return new Blake2b(outlen, key, salt, personal)
 }
 
-export const ready = (cb: Function) => {  
-  const ua = navigator.userAgent.toLowerCase()
-  const IOSVersion = ua.match(/cpu iphone os (.*?) like mac os/)
-  
+export const ready = (cb: Function) => {
+  const { window } = new Window()
+  const ua = window.navigator.userAgent.toLowerCase()
+  const iOSVersion = ua.match(/cpu iphone os (.*?) like mac os/)
+
   // ios11 is not fully compatible wasm and change model to blakejs
-  if (IOSVersion && IOSVersion[1].split('_')[0] === 11) {
+  if (iOSVersion && iOSVersion[1].split('_')[0] === '11') {
     new Promise(() => {
       // within the 64 byte ranges defined by the constants below
       const output = new Uint8Array(64)
       blake2bjs(output.length)
-    }).then(() => { 
+    }).then(() => {
       cb()
     })
   } else {

--- a/packages/ckb-sdk-utils/src/crypto/blake2b.ts
+++ b/packages/ckb-sdk-utils/src/crypto/blake2b.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 const b2wasm = require('blake2b-wasm')
+const blake2bjs = require('blake2b')
 const {
   OutLenTooSmallException,
   OutLenTooLargeException,
@@ -374,10 +375,24 @@ export const blake2b = (
   return new Blake2b(outlen, key, salt, personal)
 }
 
-export const ready = (cb: Function) => {
-  b2wasm.ready(() => {
-    cb()
-  })
+export const ready = (cb: Function) => {  
+  const ua = navigator.userAgent.toLowerCase()
+  const IOSVersion = ua.match(/cpu iphone os (.*?) like mac os/)
+  
+  // ios11 is not fully compatible wasm and change model to blakejs
+  if (IOSVersion && IOSVersion[1].split('_')[0] === 11) {
+    new Promise(() => {
+      // within the 64 byte ranges defined by the constants below
+      const output = new Uint8Array(64)
+      blake2bjs(output.length)
+    }).then(() => { 
+      cb()
+    })
+  } else {
+    b2wasm.ready(() => {
+      cb()
+    })
+  }
 }
 
 export default blake2b

--- a/packages/ckb-sdk-utils/tsconfig.json
+++ b/packages/ckb-sdk-utils/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "target": "es6",
     "outDir": "lib",
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "typeRoots": ["types", "node_modules/@types", "node_modules"],
     "types": ["@nervosnetwork/ckb-types", "node"]
   },


### PR DESCRIPTION
- 由于`IOS11`系统自身`jsc`的问题，无法完全兼容`blake2b-wasm`，目前只对该系统做特殊处理，使用`blake2b`纯js包进行兼容。 
