### PR TITLE
feat: disable blake2b-wasm when the host is iOS 11

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,8 @@ module.exports = {
     }]
   },
   "globals": {
-    "BigInt": "readonly"
+    "BigInt": "readonly",
+    "globalThis": "readonly",
   },
   "env": {
     "node": true,

--- a/packages/ckb-sdk-utils/src/crypto/blake2b.ts
+++ b/packages/ckb-sdk-utils/src/crypto/blake2b.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-const b2wasm = require('blake2b-wasm')
 const {
   OutLenTooSmallException,
   OutLenTooLargeException,
@@ -375,8 +374,16 @@ export const blake2b = (
 }
 
 export const ready = (cb: Function) => {
-  b2wasm.ready(() => {
-    cb()
+  const iOSVersion = globalThis?.navigator?.userAgent.match(/cpu iphone os (.*?) like mac os/i)
+  if (iOSVersion?.[1].startsWith('11_')) {
+    cb(new Error(`blake2b-wasm is unavailable on iOS 11`))
+    return
+  }
+
+  /* eslint-disable global-require */
+  const b2wasm = require('blake2b-wasm')
+  b2wasm.ready((...args: unknown[]) => {
+    cb(...args)
   })
 }
 

--- a/packages/ckb-sdk-utils/tsconfig.json
+++ b/packages/ckb-sdk-utils/tsconfig.json
@@ -4,9 +4,9 @@
     "moduleResolution": "node",
     "target": "es6",
     "outDir": "lib",
-    "lib": ["es2017"],
+    "lib": ["DOM"],
     "typeRoots": ["types", "node_modules/@types", "node_modules"],
     "types": ["@nervosnetwork/ckb-types", "node"]
   },
-  "include": ["src"],
+  "include": ["src"]
 }


### PR DESCRIPTION
This commit prevents `blake2b-wasm` from being loaded when it's iOS 11.