### PR TITLE
feat(utils): remove support of blake2b-wasm@v2.1.0

### DIFF
--- a/packages/ckb-sdk-utils/__tests__/crypto/blake2b.test.js
+++ b/packages/ckb-sdk-utils/__tests__/crypto/blake2b.test.js
@@ -1,5 +1,4 @@
 const { blake2b, PERSONAL } = require('../..')
-const { ready } = require('../../lib/crypto/blake2b')
 const fixtures = require('./blake2b.fixtures.json')
 
 describe('blake2b', () => {
@@ -46,56 +45,5 @@ describe('blake2b', () => {
       const digest = s.digest('hex')
       expect(digest).toBe(out)
     }
-  })
-})
-
-describe('blake2b-wasm-ready', () => {
-  afterEach(() => {
-    delete globalThis.navigator
-  })
-
-  describe("When it's in browser but not iOS 11", () => {
-    beforeEach(() => {
-      Object.defineProperty(globalThis, 'navigator', {
-        value: {
-          userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_4 like Mac OS X)',
-        },
-      })
-    })
-
-    it('callback should be invoked without error', () => {
-      expect.assertions(1)
-      ready(err => {
-        expect(err).toBeUndefined()
-      })
-    })
-  })
-
-  describe("When it's not in browser and navigator is undefined", () => {
-    beforeEach(() => {
-      delete globalThis.navigator
-    })
-    it('callback should be invoked without error', () => {
-      expect.assertions(1)
-      ready(err => {
-        expect(err).toBeUndefined()
-      })
-    })
-  })
-
-  describe("When it's iOS 11", () => {
-    beforeEach(() => {
-      Object.defineProperty(globalThis, 'navigator', {
-        value: {
-          userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_1 like Mac OS X)',
-        },
-      })
-    })
-    it('callback should be invoked with error', () => {
-      expect.assertions(1)
-      ready(err => {
-        expect(err).toEqual(new Error('blake2b-wasm is unavailable on iOS 11'))
-      })
-    })
   })
 })

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-types": "0.36.1",
-    "blake2b-wasm": "2.1.0",
     "elliptic": "6.5.3",
     "jsbi": "3.1.3",
     "tslib": "2.0.1"

--- a/packages/ckb-sdk-utils/src/crypto/blake2b.ts
+++ b/packages/ckb-sdk-utils/src/crypto/blake2b.ts
@@ -373,18 +373,4 @@ export const blake2b = (
   return new Blake2b(outlen, key, salt, personal)
 }
 
-export const ready = (cb: Function) => {
-  const iOSVersion = globalThis?.navigator?.userAgent.match(/cpu iphone os (.*?) like mac os/i)
-  if (iOSVersion?.[1].startsWith('11_')) {
-    cb(new Error(`blake2b-wasm is unavailable on iOS 11`))
-    return
-  }
-
-  /* eslint-disable global-require */
-  const b2wasm = require('blake2b-wasm')
-  b2wasm.ready((...args: unknown[]) => {
-    cb(...args)
-  })
-}
-
 export default blake2b

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,13 +2305,6 @@ bitcoinjs-lib@*:
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-blake2b-wasm@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.1.0.tgz#aa90ed687b8a92e1c01d1643db86bcf21caa2ab7"
-  integrity sha512-8zKXt9nk4cUCBU2jaUcSYcPA+UESwWOmb9Gsi8J35BifVb+tjVmbDhZbvmVmZEk6xZN1y35RNW6VqOwb0mkqsg==
-  dependencies:
-    nanoassert "^1.0.0"
-
 blake2b-wasm@^1.1.0:
   version "1.1.7"
   resolved "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz#e4d075da10068e5d4c3ec1fb9accc4d186c55d81"


### PR DESCRIPTION
Remove explicit support of blake2b-wasm since it's not used in any projects while  blake2b-wasm@v1.1.0 is used implicitly by blake2b.

BREAKING CHANGE: Remove explicit support of blake2b-wasm@v2.1.0