### PR TITLE
fix(core): use change lock script instead of change public key hash

### DIFF
--- a/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
+++ b/packages/ckb-sdk-core/__tests__/generateRawTransaction/fixtures.json
@@ -225,7 +225,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -470,7 +470,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -716,7 +716,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -969,7 +969,7 @@
             "capacity": "0x20001c425c",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -983,6 +983,256 @@
             "lock": ""
           },
           "0x",
+          "0x",
+          "0x",
+          "0x",
+          "0x",
+          "0x"
+        ]
+      }
+    },
+    "should use secp256k1 lock when change lock script is set": {
+      "params": {
+        "inputScript": {
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "outputScript": {
+          "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "hashType": "type"
+        },
+        "changeLockScript": {
+          "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+          "hashType": "type",
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0"
+        },
+        "capacity": 783602000000,
+        "fee": 13670,
+        "cells": [
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x0"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x1"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x2"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x3"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x4"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x5"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x6"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x7"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x8"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          },
+          {
+            "lock": {
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type",
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
+            },
+            "outPoint": {
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2",
+              "index": "0x9"
+            },
+            "capacity": "0x1fd52bc92e",
+            "data": "0x"
+          }
+        ],
+        "deps": {
+          "hashType": "type",
+          "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+          "outPoint": {
+            "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091",
+            "index": "0x0"
+          },
+          "depType": "depGroup"
+        }
+      },
+      "expected": {
+        "cellDeps": [
+          {
+            "depType": "depGroup",
+            "outPoint": {
+              "index": "0x0",
+              "txHash": "0x6347ee7ce5fc6828133590558b867097b895149a66e51cf353c361f7128e2091"
+            }
+          }
+        ],
+        "headerDeps": [],
+        "inputs": [
+          {
+            "previousOutput": {
+              "index": "0x1",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x2",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x3",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x4",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x5",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          },
+          {
+            "previousOutput": {
+              "index": "0x6",
+              "txHash": "0x9160bef8b6a9e388a99184bfd8bea0e7795b487c77fe784120fb2bc3fb25d1b2"
+            },
+            "since": "0x0"
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "0xb67251a080",
+            "lock": {
+              "args": "0xddbd7f09eb480450c1b1ed2c8696248de91c6802",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
+              "hashType": "type"
+            }
+          },
+          {
+            "capacity": "0x88cb4e12e",
+            "lock": {
+              "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0",
+              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hashType": "type"
+            }
+          }
+        ],
+        "outputsData": ["0x", "0x"],
+        "version": "0x0",
+        "witnesses": [
+          {
+            "inputType": "",
+            "outputType": "",
+            "lock": ""
+          },
           "0x",
           "0x",
           "0x",
@@ -1005,7 +1255,11 @@
             "hashType": "type"
           }
         ],
-        "changePublicKeyHash": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0",
+        "changeLockScript": {
+          "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+          "hashType": "type",
+          "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f0"
+        },
         "outputs": [
           {
             "lock": {
@@ -1401,7 +1655,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -1649,7 +1903,7 @@
             "capacity": "0x88cb4e12e",
             "lock": {
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6",
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type"
             }
           }
@@ -1793,7 +2047,7 @@
           {
             "capacity": "0x16b969d00",
             "lock": {
-              "codeHash": "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "codeHash": "0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2",
               "hashType": "type",
               "args": "0xe2fa82e70b062c8644b80ad7ecf6e015e5f352f6"
             }

--- a/packages/ckb-sdk-core/src/generateRawTransaction.ts
+++ b/packages/ckb-sdk-core/src/generateRawTransaction.ts
@@ -1,4 +1,4 @@
-import { scriptToHash, JSBI, systemScripts } from '@nervosnetwork/ckb-sdk-utils'
+import { scriptToHash, JSBI } from '@nervosnetwork/ckb-sdk-utils'
 import { EMPTY_WITNESS_ARGS } from '@nervosnetwork/ckb-sdk-utils/lib/const'
 import { assertToBeHexStringOrBigint } from '@nervosnetwork/ckb-sdk-utils/lib/validators'
 
@@ -133,7 +133,7 @@ const isFee = (fee: RawTransactionParams.Fee): fee is RawTransactionParams.Capac
 
 const generateRawTransaction = ({
   fee = '0x0',
-  changePublicKeyHash,
+  changeLockScript,
   safeMode = true,
   deps,
   capacityThreshold = MIN_CELL_CAPACITY,
@@ -153,13 +153,10 @@ const generateRawTransaction = ({
   const targetOutputs = getTargetOutputs({ outputs: toOutputs, minCapacity })
   const targetCapacity = targetOutputs.reduce((acc, o) => JSBI.add(acc, o.capacity), zeroBigInt)
   const costCapacity = JSBI.add(JSBI.add(targetCapacity, targetFee), minChange)
+
   const changeOutput = {
     capacity: zeroBigInt,
-    lock: {
-      codeHash: systemScripts.SECP256K1_BLAKE160.codeHash,
-      hashType: systemScripts.SECP256K1_BLAKE160.hashType,
-      args: changePublicKeyHash || inputScripts[0].args,
-    },
+    lock: changeLockScript || inputScripts[0],
   }
 
   const { inputs, sum: inputSum } = getInputs({ inputScripts, safeMode, costCapacity, unspentCellsMap })

--- a/packages/ckb-sdk-core/types/global.d.ts
+++ b/packages/ckb-sdk-core/types/global.d.ts
@@ -30,7 +30,6 @@ declare namespace LoadCellsParams {
 
 declare namespace RawTransactionParams {
   type LockHash = string
-  type PublicKeyHash = string
   type Capacity = string | bigint
   type Cell = {
     data: string
@@ -57,7 +56,7 @@ declare namespace RawTransactionParams {
     deps: DepCellInfo | DepCellInfo[]
     capacityThreshold?: Capacity
     changeThreshold?: Capacity
-    changePublicKeyHash?: PublicKeyHash
+    changeLockScript?: Script
     witnesses?: Array<CKBComponents.WitnessArgs | CKBComponents.Witness>
     outputsData?: Array<string>
   }


### PR DESCRIPTION
This commit replaces the `change public key hash` in `generateRawTransaction` with `change lock
script` so the change lock script is not bound to secp256k1 lock script.

BREAKING CHANGE: `changePublicKeyHash` in `generateRawTransaction` is replaced with
`changeLockScript`