### PR TITLE
Release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)
+
+
+### Features
+
+* **rpc:** add rpc#getRawTxPool, rpc#getConsensus and deprecate rpc#getCellbaseOutputCapacityDetails, rpc#getPeersState ([#528](https://github.com/nervosnetwork/ckb-sdk-js/pull/528))
+
+
+
+
+
 ## [0.38.2](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.1...v0.38.2) (2020-11-30)
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The ckb-sdk-js is still under development and NOT production ready. You should g
 - [RPC](#rpc)
 - [Errors](#errors)
 - [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
 - [Development Process](#development-process)
 
 <p>
@@ -228,6 +229,13 @@ The rpc module will throw an error when the result contains an error field, you 
 5. [Send Transaction with Lumos Collector](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js)
 6. [SUDT](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sudt.js)
 
+# Troubleshooting
+
+## Indexer Module
+
+The Indexer Module in CKB has been deprecated since [v0.36.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.36.0), please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) or [lumos-indexer](https://github.com/nervosnetwork/lumos/tree/develop/packages/indexer) instead.
+
+A simple example [sendTransactionWithLumosCollector](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js) of wokring with lumos has beed added.
 
 # Development Process
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The ckb-sdk-js is still under development and NOT production ready. You should g
 - [Modules](#modules)
 - [CORE](#core)
 - [RPC](#rpc)
+- [Utils](#utils)
 - [Errors](#errors)
 - [Examples](#examples)
 - [Troubleshooting](#troubleshooting)
@@ -213,6 +214,10 @@ const https = require('https')
 const httpsAgent = new https.Agent({ keepAlive: true })
 ckb.rpc.setNode({ httpsAgent })
 ```
+
+# Utils
+
+[Most used utilities](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/README.md)
 
 # Errors
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.38.2"
+  "version": "0.39.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-core
+
+
+
+
+
 ## [0.38.2](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.1...v0.38.2) (2020-11-30)
 
 

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,9 +31,9 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.38.2",
-    "@nervosnetwork/ckb-sdk-utils": "0.38.2",
-    "@nervosnetwork/ckb-types": "0.38.2",
+    "@nervosnetwork/ckb-sdk-rpc": "0.39.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.39.0",
+    "@nervosnetwork/ckb-types": "0.39.0",
     "tslib": "2.0.1"
   },
   "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -36,5 +36,5 @@
     "@nervosnetwork/ckb-types": "0.39.0",
     "tslib": "2.0.1"
   },
-  "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"
+  "gitHead": "94af87551108a40f79c1cead0db5d3cc5c679302"
 }

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)
+
+
+### Features
+
+* **rpc:** add rpc#getRawTxPool, rpc#getConsensus and deprecate rpc#getCellbaseOutputCapacityDetails, rpc#getPeersState ([#528](https://github.com/nervosnetwork/ckb-sdk-js/pull/528))
+
+
+
+
+
 ## [0.38.2](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.1...v0.38.2) (2020-11-30)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
@@ -32,8 +32,8 @@ describe('ckb-rpc settings and helpers', () => {
     expect(rpc.node.httpsAgent).toBeDefined()
   })
 
-  it('has 37 basic rpc', () => {
-    expect(Object.values(rpc)).toHaveLength(37)
+  it('has 39 basic rpc', () => {
+    expect(Object.values(rpc)).toHaveLength(39)
   })
 
   it('set node url to http://test.localhost:8114', () => {

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -197,6 +197,144 @@ describe('Test with mock', () => {
       expect(res).toBeNull()
     })
 
+    describe('get raw tx pool', () => {
+      it('verbose = true', async () => {
+        axiosMock.mockResolvedValue({
+          data: {
+            id,
+            jsonrpc: '2.0',
+            result: {
+              proposed: {
+                '0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0': {
+                  ancestors_count: '0x1',
+                  ancestors_cycles: '0x1a00e0',
+                  ancestors_size: '0x1d0',
+                  cycles: '0x1a00e0',
+                  fee: '0x989680',
+                  size: '0x1d0',
+                },
+              },
+              pending: {
+                '0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0': {
+                  ancestors_count: '0x1',
+                  ancestors_cycles: '0x1a00e0',
+                  ancestors_size: '0x1d0',
+                  cycles: '0x1a00e0',
+                  fee: '0x989680',
+                  size: '0x1d0',
+                },
+              },
+            },
+          },
+        })
+
+        const res = await rpc.getRawTxPool(true)
+        expect(axiosMock.mock.calls[0][0].data).toEqual({
+          id,
+          jsonrpc: '2.0',
+          method: 'get_raw_tx_pool',
+          params: [true],
+        })
+        expect(res).toEqual({
+          proposed: {
+            '0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0': {
+              ancestorsCount: '0x1',
+              ancestorsCycles: '0x1a00e0',
+              ancestorsSize: '0x1d0',
+              cycles: '0x1a00e0',
+              fee: '0x989680',
+              size: '0x1d0',
+            },
+          },
+          pending: {
+            '0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0': {
+              ancestorsCount: '0x1',
+              ancestorsCycles: '0x1a00e0',
+              ancestorsSize: '0x1d0',
+              cycles: '0x1a00e0',
+              fee: '0x989680',
+              size: '0x1d0',
+            },
+          },
+        })
+      })
+
+      it('verbose = false', async () => {
+        axiosMock.mockResolvedValue({
+          data: {
+            id,
+            jsonrpc: '2.0',
+            result: {
+              pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+              proposed: [],
+            },
+          },
+        })
+
+        const res = await rpc.getRawTxPool(false)
+        expect(axiosMock.mock.calls[0][0].data).toEqual({
+          id,
+          jsonrpc: '2.0',
+          method: 'get_raw_tx_pool',
+          params: [false],
+        })
+        expect(res).toEqual({
+          pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+          proposed: [],
+        })
+      })
+
+      it('verbose = null', async () => {
+        axiosMock.mockResolvedValue({
+          data: {
+            id,
+            jsonrpc: '2.0',
+            result: {
+              pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+              proposed: [],
+            },
+          },
+        })
+
+        const res = await rpc.getRawTxPool(null)
+        expect(axiosMock.mock.calls[0][0].data).toEqual({
+          id,
+          jsonrpc: '2.0',
+          method: 'get_raw_tx_pool',
+          params: [null],
+        })
+        expect(res).toEqual({
+          pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+          proposed: [],
+        })
+      })
+
+      it('verbose = undefined', async () => {
+        axiosMock.mockResolvedValue({
+          data: {
+            id,
+            jsonrpc: '2.0',
+            result: {
+              pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+              proposed: [],
+            },
+          },
+        })
+
+        const res = await rpc.getRawTxPool()
+        expect(axiosMock.mock.calls[0][0].data).toEqual({
+          id,
+          jsonrpc: '2.0',
+          method: 'get_raw_tx_pool',
+          params: [],
+        })
+        expect(res).toEqual({
+          pending: ['0x272881d99bfa40ded47f408e1783ee15990b479ec462f11668cdd3445cc132b0'],
+          proposed: [],
+        })
+      })
+    })
+
     it('get current epoch', async () => {
       axiosMock.mockResolvedValue({
         data: {
@@ -492,6 +630,74 @@ describe('Test with mock', () => {
       })
       expect(res).toEqual(['0xa4037a893eb48e18ed4ef61034ce26eba9c585f15c9cee102ae58505565eccc3'])
     })
+
+    it('get consensus', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          id,
+          jsonrpc: '2.0',
+          result: {
+            block_version: '0x0',
+            cellbase_maturity: '0x10000000000',
+            dao_type_hash: '0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e',
+            epoch_duration_target: '0x3840',
+            genesis_hash: '0xeaa2c979898f80a12404578a9e1332d45c8ff2bf665457b10f9934203f230780',
+            id: 'ckb_dev',
+            initial_primary_epoch_reward: '0xae6c73c3e070',
+            max_block_bytes: '0x91c08',
+            max_block_cycles: '0x2540be400',
+            max_block_proposals_limit: '0x5dc',
+            max_uncles_num: '0x2',
+            median_time_block_count: '0x25',
+            orphan_rate_target: { denom: '0x28', numer: '0x1' },
+            permanent_difficulty_in_dummy: true,
+            primary_epoch_reward_halving_interval: '0x2238',
+            proposer_reward_ratio: { denom: '0xa', numer: '0x4' },
+            secondary_epoch_reward: '0x37d0c8e28542',
+            secp256k1_blake160_multisig_all_type_hash:
+              '0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8',
+            secp256k1_blake160_sighash_all_type_hash:
+              '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+            tx_proposal_window: { closest: '0x2', farthest: '0xa' },
+            tx_version: '0x0',
+            type_id_code_hash: '0x00000000000000000000000000000000000000000000000000545950455f4944',
+          },
+        },
+      })
+
+      const res = await rpc.getConsensus()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_consensus',
+        params: [],
+      })
+      expect(res).toEqual({
+        blockVersion: '0x0',
+        cellbaseMaturity: '0x10000000000',
+        daoTypeHash: '0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e',
+        epochDurationTarget: '0x3840',
+        genesisHash: '0xeaa2c979898f80a12404578a9e1332d45c8ff2bf665457b10f9934203f230780',
+        id: 'ckb_dev',
+        initialPrimaryEpochReward: '0xae6c73c3e070',
+        maxBlockBytes: '0x91c08',
+        maxBlockCycles: '0x2540be400',
+        maxBlockProposalsLimit: '0x5dc',
+        maxUnclesNum: '0x2',
+        medianTimeBlockCount: '0x25',
+        orphanRateTarget: { denom: '0x28', numer: '0x1' },
+        permanentDifficultyInDummy: true,
+        primaryEpochRewardHalvingInterval: '0x2238',
+        proposerRewardRatio: { denom: '0xa', numer: '0x4' },
+        secondaryEpochReward: '0x37d0c8e28542',
+        secp256k1Blake160MultisigAllTypeHash: '0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8',
+        secp256k1Blake160SighashAllTypeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+        txProposalWindow: { closest: '0x2', farthest: '0xa' },
+        txVersion: '0x0',
+        typeIdCodeHash: '0x00000000000000000000000000000000000000000000000000545950455f4944',
+      })
+    })
+
     it('get blockchain info', async () => {
       axiosMock.mockResolvedValue({
         data: {

--- a/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/ckb-sdk-rpc/__tests__/formatters/result.fixtures.json
@@ -1471,5 +1471,135 @@
         "witnessesRoot": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
       }
     }
+  ],
+  "toConsensus": [
+    {
+      "result": null,
+      "expected": null
+    },
+    {
+      "result": {
+        "block_version": "0x0",
+        "cellbase_maturity": "0x10000000000",
+        "dao_type_hash": null,
+        "epoch_duration_target": "0x3840",
+        "genesis_hash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
+        "id": "main",
+        "initial_primary_epoch_reward": "0x71afd498d000",
+        "max_block_bytes": "0x91c08",
+        "max_block_cycles": "0xd09dc300",
+        "max_block_proposals_limit": "0x5dc",
+        "max_uncles_num": "0x2",
+        "median_time_block_count": "0x25",
+        "orphan_rate_target": {
+          "denom": "0x28",
+          "numer": "0x1"
+        },
+        "permanent_difficulty_in_dummy": false,
+        "primary_epoch_reward_halving_interval": "0x2238",
+        "proposer_reward_ratio": {
+          "denom": "0xa",
+          "numer": "0x4"
+        },
+        "secondary_epoch_reward": "0x37d0c8e28542",
+        "secp256k1_blake160_multisig_all_type_hash": null,
+        "secp256k1_blake160_sighash_all_type_hash": null,
+        "tx_proposal_window": {
+          "closest": "0x2",
+          "farthest": "0xa"
+        },
+        "tx_version": "0x0",
+        "type_id_code_hash": "0x00000000000000000000000000000000000000000000000000545950455f4944"
+      },
+      "expected": {
+        "blockVersion": "0x0",
+        "cellbaseMaturity": "0x10000000000",
+        "daoTypeHash": null,
+        "epochDurationTarget": "0x3840",
+        "genesisHash": "0x7978ec7ce5b507cfb52e149e36b1a23f6062ed150503c85bbf825da3599095ed",
+        "id": "main",
+        "initialPrimaryEpochReward": "0x71afd498d000",
+        "maxBlockBytes": "0x91c08",
+        "maxBlockCycles": "0xd09dc300",
+        "maxBlockProposalsLimit": "0x5dc",
+        "maxUnclesNum": "0x2",
+        "medianTimeBlockCount": "0x25",
+        "orphanRateTarget": {
+          "denom": "0x28",
+          "numer": "0x1"
+        },
+        "permanentDifficultyInDummy": false,
+        "primaryEpochRewardHalvingInterval": "0x2238",
+        "proposerRewardRatio": {
+          "denom": "0xa",
+          "numer": "0x4"
+        },
+        "secondaryEpochReward": "0x37d0c8e28542",
+        "secp256k1Blake160MultisigAllTypeHash": null,
+        "secp256k1Blake160SighashAllTypeHash": null,
+        "txProposalWindow": {
+          "closest": "0x2",
+          "farthest": "0xa"
+        },
+        "txVersion": "0x0",
+        "typeIdCodeHash": "0x00000000000000000000000000000000000000000000000000545950455f4944"
+      }
+    }
+  ],
+  "toRawTxPool": [
+    {
+      "result": null,
+      "expected": null
+    },
+    {
+      "result": { "proposed": ["proposed_1", "proposed_2"], "pending": ["pending_1", "pending_2"] },
+      "expected": { "proposed": ["proposed_1", "proposed_2"], "pending": ["pending_1", "pending_2"] }
+    },
+    {
+      "result": {
+        "pending": {
+          "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+            "cycles": "0x219eee",
+            "size": "0x112eee",
+            "fee": "0x16923f7dcfeee",
+            "ancestors_size": "0x112eee",
+            "ancestors_cycles": "0x219eee",
+            "ancestors_count": "0x1eee"
+          }
+        },
+        "proposed": {
+          "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+            "cycles": "0x219fff",
+            "size": "0x112fff",
+            "fee": "0x16923f7dcffff",
+            "ancestors_size": "0x112fff",
+            "ancestors_cycles": "0x219fff",
+            "ancestors_count": "0x1fff"
+          }
+        }
+      },
+      "expected": {
+        "pending": {
+          "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+            "cycles": "0x219eee",
+            "size": "0x112eee",
+            "fee": "0x16923f7dcfeee",
+            "ancestorsSize": "0x112eee",
+            "ancestorsCycles": "0x219eee",
+            "ancestorsCount": "0x1eee"
+          }
+        },
+        "proposed": {
+          "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+            "cycles": "0x219fff",
+            "size": "0x112fff",
+            "fee": "0x16923f7dcffff",
+            "ancestorsSize": "0x112fff",
+            "ancestorsCycles": "0x219fff",
+            "ancestorsCount": "0x1fff"
+          }
+        }
+      }
+    }
   ]
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-utils": "0.38.2",
-    "axios": "0.19.2",
+    "axios": "0.21.1",
     "tslib": "2.0.1"
   },
   "devDependencies": {

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,12 +33,12 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.38.2",
+    "@nervosnetwork/ckb-sdk-utils": "0.39.0",
     "axios": "0.21.1",
     "tslib": "2.0.1"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.38.2"
+    "@nervosnetwork/ckb-types": "0.39.0"
   },
   "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -40,5 +40,5 @@
   "devDependencies": {
     "@nervosnetwork/ckb-types": "0.39.0"
   },
-  "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"
+  "gitHead": "94af87551108a40f79c1cead0db5d3cc5c679302"
 }

--- a/packages/ckb-sdk-rpc/src/Base/chain.ts
+++ b/packages/ckb-sdk-rpc/src/Base/chain.ts
@@ -89,4 +89,10 @@ export default {
     method: 'verify_transaction_proof',
     paramsFormatters: [paramsFmts.toTransactionProof],
   },
+
+  getConsensus: {
+    method: 'get_consensus',
+    paramsFormatters: [],
+    resultFormatters: resultFmts.toConsensus,
+  },
 }

--- a/packages/ckb-sdk-rpc/src/Base/index.ts
+++ b/packages/ckb-sdk-rpc/src/Base/index.ts
@@ -78,7 +78,7 @@ export interface Base {
    * @method getHeader
    * @memberof DefaultRPC
    * @description Returns the information about a block header by hash.
-   * @params {string} block hash
+   * @params {Promise<string>} block hash
    */
   getHeader: (blockHash: CKBComponents.Hash) => Promise<CKBComponents.BlockHeader>
 
@@ -86,7 +86,7 @@ export interface Base {
    * @method getHeaderByNumber
    * @memberof DefaultRPC
    * @description Returns the information about a block header by block number
-   * @params {string} block number
+   * @params {Promise<string>} block number
    */
   getHeaderByNumber: (blockNumber: CKBComponents.BlockNumber | bigint) => Promise<CKBComponents.BlockHeader>
 
@@ -122,6 +122,8 @@ export interface Base {
    * @description Returns each component of the created CKB in this block's cellbase, which is issued to
    *              a block N - 1 - ProposalWindow.farthest, where this block's height is N.
    * @param {string} blockHash
+   *
+   * @deprecated will be removed from v0.40.0
    */
   getCellbaseOutputCapacityDetails: (
     blockHash: CKBComponents.Hash,
@@ -141,7 +143,7 @@ export interface Base {
    * @memberof DefaultRPC
    * @description request merkle proof that transactions are included in a block
    * @param {Array<string>} transactionHashes - transaction hashes, all transactions must be in the same block
-   * @param {[string]} blockHash - if specified, looks for transactions in the block with this hash
+   * @param {Promise<[string]>} blockHash - if specified, looks for transactions in the block with this hash
    */
   getTransactionProof: (
     transactionHashes: CKBComponents.Hash[],
@@ -153,9 +155,17 @@ export interface Base {
    * @memberof DefaultRPC
    * @description verifies that a proof points to transactions in a block, returns transactions it commits to.
    * @param {object} transactionProof
-   * @returns {Array<string>} hash list of transactions committed in the block
+   * @returns {Promise<Array<string>>} hash list of transactions committed in the block
    */
   verifyTransactionProof: (transactionProof: CKBComponents.TransactionProof) => Promise<CKBComponents.Hash[]>
+
+  /**
+   * @method getConsensus
+   * @memberof DefaultRPC
+   * @description return various consensus parameters.
+   * @returns {Promise<object>} consensus parameters
+   */
+  getConsensus: () => Promise<CKBComponents.Consensus>
 
   /**
    * @method getBlockByNumber
@@ -178,16 +188,10 @@ export interface Base {
    */
   dryRunTransaction: (tx: CKBComponents.RawTransaction) => Promise<CKBComponents.RunDryResult>
 
-  // skip _compute_transaction_hash
-
   calculateDaoMaximumWithdraw: (
     outPoint: CKBComponents.OutPoint,
     withdrawBlockHash: CKBComponents.Hash256,
   ) => Promise<string>
-
-  // skip estimate_fee_rate
-
-  // skip _compute_script_hash
 
   /* Indexer */
 
@@ -285,6 +289,8 @@ export interface Base {
    * @memberof DefaultRPC
    * @description rpc to get connected peers info
    * @return {Promise<object[]>} peers' node info
+   *
+   * @deprecated will be removed from v0.40.0
    */
   getPeers: () => Promise<CKBComponents.RemoteNodeInfo[]>
 
@@ -401,6 +407,17 @@ export interface Base {
    * @return {Promise<null>}
    */
   clearTxPool: () => Promise<null>
+
+  /**
+   * @method getRawTxPool
+   * @memberof DefaultRPC
+   * @param {boolean | null} verbose - true for a json object, false for array of transaction ids, default=false
+   * @description Returns all transaction ids in tx pool as a json array of string transaction ids.
+   * @return {Promise<object>} CKBComponents.RawTxPool
+   */
+  getRawTxPool(): Promise<CKBComponents.TxPoolIds>
+  getRawTxPool(verbose: true): Promise<CKBComponents.TxPoolVerbosity>
+  getRawTxPool(verbose: false | null): Promise<CKBComponents.TxPoolIds>
 
   /* Stats */
 

--- a/packages/ckb-sdk-rpc/src/Base/pool.ts
+++ b/packages/ckb-sdk-rpc/src/Base/pool.ts
@@ -18,4 +18,10 @@ export default {
     method: 'clear_tx_pool',
     paramsFormatters: [],
   },
+
+  getRawTxPool: {
+    method: 'get_raw_tx_pool',
+    paramsFormatters: [],
+    resultFormatters: resultFmts.toRawTxPool,
+  },
 }

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -23,6 +23,9 @@ declare module RPC {
   export type Difficulty = CKBComponents.Difficulty
   export type Cycles = CKBComponents.Cycles
   export type Size = CKBComponents.Size
+  export type RationalU256 = CKBComponents.RationalU256
+  export type ProposalWindow = CKBComponents.ProposalWindow
+  export type EpochNumberWithFraction = CKBComponents.EpochNumberWithFraction
 
   enum TransactionStatus {
     Pending = 'pending',
@@ -291,6 +294,46 @@ declare module RPC {
       lemmas: Hash[]
     }
     witnesses_root: Hash
+  }
+
+  export type TxPoolIds = Record<'pending' | 'proposed', Array<Hash256>>
+
+  export interface TxVerbosity {
+    cycles: Cycles
+    size: Size
+    fee: Capacity
+    ancestors_size: Size
+    ancestors_cycles: Cycles
+    ancestors_count: Count
+  }
+
+  export type TxPoolVerbosity = Record<'pending' | 'proposed', Record<Hash256, TxVerbosity>>
+
+  export type RawTxPool = TxPoolIds | TxPoolVerbosity
+
+  export interface Consensus {
+    id: string
+    genesis_hash: Hash256
+    dao_type_hash: Hash256 | null
+    secp256k1_blake160_sighash_all_type_hash: Hash256 | null
+    secp256k1_blake160_multisig_all_type_hash: Hash256 | null
+    initial_primary_epoch_reward: Capacity
+    secondary_epoch_reward: Capacity
+    max_uncles_num: string
+    orphan_rate_target: RationalU256
+    epoch_duration_target: string
+    tx_proposal_window: ProposalWindow
+    proposer_reward_ratio: RationalU256
+    cellbase_maturity: EpochNumberWithFraction
+    median_time_block_count: Count
+    max_block_cycles: Cycles
+    max_block_bytes: string
+    block_version: Version
+    tx_version: Version
+    type_id_code_hash: Hash256
+    max_block_proposals_limit: string
+    primary_epoch_reward_halving_interval: string
+    permanent_difficulty_in_dummy: boolean
   }
 }
 /* eslint-enable camelcase */

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 ## [0.38.2](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.1...v0.38.2) (2020-11-30)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/README.md
+++ b/packages/ckb-sdk-utils/README.md
@@ -3,3 +3,201 @@
 `@nervosnetwork/ckb-sdk-utils` is the utils module of `@nervosnetwork/ckb-sdk-core`, which provides necessary methods for the sdk, including encryption, key-pair generation, address generation and so on.
 
 See [Full Doc](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/README.md)
+
+## Most Used Utilities
+
+- [Address](#address)
+
+  - `utils.AddressPrefix`
+  - `utils.AddressType`
+  - `utils.privateKeyToAddress`: get address from private key
+  - `utils.pubkeyToAddress`: get address from public key
+  - `utils.bech32Address`: args to short/full version address
+  - `utils.fullPayloadToAddress`: script to full version address
+  - `utils.parseAddress`: get address payload
+  - `utils.addressToScript`: get lock script from address
+
+- [Utils](#utils)
+
+  - `utils.blake160`
+  - `utils.bytesToHex`
+  - `utils.hexToBytes`
+  - `utils.toUint16Le`
+  - `utils.toUint32Le`
+  - `utils.toUint64Le`
+
+- [System Scripts](#system-scripts)
+
+### Address
+
+```js
+/**
+ * @description address prefix
+ * @see https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md#wrap-to-address
+ */
+utils.AddressPrefix
+// {
+//   Mainnet: 'ckb', // mainnet prefix
+//   Testnet: 'ckt', // testnet prefix
+// }
+```
+
+```js
+/**
+ * @description address payload format types
+ * @see https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md#payload-format-types
+ */
+utils.AddressType
+// {
+//   HashIdx: '0x01',      // short version address
+//   DataCodeHash: '0x02', // full version address with hash type = 'data'
+//   TypeCodeHash: '0x04', // full version address with hash type = 'type'
+// }
+```
+
+```js
+/**
+ * @description get short version address by private key
+ */
+utils.privateKeyToAddress('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee', {
+  prefix: utils.AddressPrefix.Mainnet, // prefix is optional, default to 'ckb'
+})
+// ckb1qyqw975zuu9svtyxgjuq44lv7mspte0n2tmqqm3w53
+```
+
+```js
+/**
+ * @description get short version address by public key
+ */
+utils.pubkeyToAddress('0x024a501efd328e062c8675f2365970728c859c592beeefd6be8ead3d901330bc01', {
+  prefix: utils.AddressPrefix.Testnet,
+})
+// ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83
+```
+
+```js
+/**
+ * @description get short/full version address from args
+ */
+utils.bech32Address('0x36c329ed630d6ce750712a477543672adab57f4c', {
+  prefix: utils.AddressPrefix.Mainnet,
+  type: utils.AddressType.HashIdx,
+  codeHashOrCodeHashIndex: '0x00',
+})
+// ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd
+```
+
+```js
+/**
+ * @description get full version address by a lock script
+ * @params args - lock.args
+ * @params type - utils.AddressType.DataCodeHash if lock.hash_type = 'data'
+ *                otherwise utils.AddressType.TypeCodeHash
+ * @params prefix - utils.AddressPrefix.Mainnet or utils.AddressPrefix.Testnet
+ * @params codeHash - lock.code_hash
+ */
+utils.fullPayloadToAddress({
+  args: '0x36c329ed630d6ce750712a477543672adab57f4c',
+  type: utils.AddressType.DataCodeHash,
+  prefix: utils.AddressPrefix.Testnet,
+  codeHash: '0xa656f172b6b45c245307aeb5a7a37a176f002f6f22e92582c58bf7ba362e4176',
+})
+// ckt1q2n9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5czshhac
+```
+
+```js
+/**
+ * @description parse short version address
+ *              the returned value is `type | index | args`,
+ *              in this case `01 | 00 | 36...4c`
+ */
+utils.parseAddress('ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83', 'hex')
+// 0x010036c329ed630d6ce750712a477543672adab57f4c
+
+/**
+ * @description parse full version address
+ *              the returned value is ` type | code hash | args`
+ *              in this case `02 | 9b...e8 | b3...64`
+ */
+utils.parseAddress(
+  'ckb1q2da0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xw3vumhs9nvu786dj9p0q5elx66t24n3kxgdwd2q8',
+  'hex',
+)
+// 0x029bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8b39bbc0b3673c7d36450bc14cfcdad2d559c6c64
+```
+
+```js
+/**
+ * @description restore lock script from a short version address
+ */
+utils.addressToScript('ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqswmu83')
+// {
+//   codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
+//   hashType: 'type',
+//   args: '0x36c329ed630d6ce750712a477543672adab57f4c'
+// }
+
+/**
+ * @description restore lock script from a full version address
+ */
+utils.addressToScript('ckb1qsvf96jqmq4483ncl7yrzfzshwchu9jd0glq4yy5r2jcsw04d7xlydkr98kkxrtvuag8z2j8w4pkw2k6k4l5czfy37k')
+// {
+//   codeHash: '0x1892ea40d82b53c678ff88312450bbb17e164d7a3e0a90941aa58839f56f8df2',
+//   hashType: 'type',
+//   args: '0x36c329ed630d6ce750712a477543672adab57f4c'
+// }
+```
+
+### Utils
+
+```plain
+/**
+ * @description get the blake160 digest of a message
+ */
+utils.blake160(
+  new Uint8Array([ 2, 74, 80, 30, 253, 50, 142, 6, 44, 134, 117, 242, 54, 89, 112, 114, 140, 133, 156, 89, 43, 238, 239, 214, 190, 142, 173, 61, 144, 19, 48, 188, 1]),
+  'hex',
+)
+// 36c329ed630d6ce750712a477543672adab57f4c
+```
+
+```js
+utils.bytesToHex(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]))
+// 0x48656c6c6f20576f726c64
+utils.hexToBytes('0x48656c6c6f20576f726c64')
+// Uint8Array [ 72, 101, 108, 108, 111,  32, 87, 111, 114, 108, 100 ]
+utils.toUint16Le('0xbcd')
+// 0xcd0b
+utils.toUint32Le('0x123456')
+// 0x56341200
+utils.toUint64Le('0x1234567890abcdef')
+// 0xefcdab9078563412
+```
+
+```js
+utils.parseEpoch('0x2003e80010000200')
+// { length: '0x3e8', index: '0x10', number: '0x200' }
+utils.serializeEpoch({ length: '0x3e8', index: '0x10', number: '0x200' })
+// 0x2003e80010000200
+```
+
+```js
+utils.rawTransactionToHash(rawTx)
+// tx hash
+```
+
+```js
+/**
+ * @description get hash of a script
+ */
+utils.scriptToHash({
+  codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  args: '0x01',
+  hashType: 'type',
+})
+// 0xd39f84d4702f53cf8625da4411be1640b961715cb36816501798fedb70b6e0fb
+```
+
+### System Scripts
+
+[System Scripts](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/src/systemScripts.ts)

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.38.2",
+    "@nervosnetwork/ckb-types": "0.39.0",
     "elliptic": "6.5.3",
     "jsbi": "3.1.3",
     "tslib": "2.0.1"

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -40,5 +40,5 @@
     "@types/bitcoinjs-lib": "5.0.0",
     "@types/elliptic": "6.4.12"
   },
-  "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"
+  "gitHead": "94af87551108a40f79c1cead0db5d3cc5c679302"
 }

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -14,7 +14,6 @@ export enum AddressPrefix {
 }
 
 export enum AddressType {
-  BinHash = '0x00',
   HashIdx = '0x01', // short version for locks with popular codehash
   DataCodeHash = '0x02', // full version with hash type 'Data'
   TypeCodeHash = '0x04', // full version with hash type 'Type'

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 ## [0.38.2](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.1...v0.38.2) (2020-11-30)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-types

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -21,6 +21,9 @@ declare namespace CKBComponents {
   export type Cycles = string
   export type Size = string
   export type OutputsValidator = 'default' | 'passthrough' | undefined
+  export type RationalU256 = Record<'denom' | 'numer', string>
+  export type ProposalWindow = Record<'closest' | 'farthest', BlockNumber>
+  export type EpochNumberWithFraction = string
   export enum TransactionStatus {
     Pending = 'pending',
     Proposed = 'proposed',
@@ -451,5 +454,45 @@ declare namespace CKBComponents {
       lemmas: Hash[]
     }
     witnessesRoot: Hash
+  }
+
+  export type TxPoolIds = Record<'pending' | 'proposed', Array<Hash256>>
+
+  export interface TxVerbosity {
+    cycles: Cycles
+    size: Size
+    fee: Capacity
+    ancestorsSize: Size
+    ancestorsCycles: Cycles
+    ancestorsCount: Count
+  }
+
+  export type TxPoolVerbosity = Record<'pending' | 'proposed', Record<Hash256, TxVerbosity>>
+
+  export type RawTxPool = TxPoolIds | TxPoolVerbosity
+
+  export interface Consensus {
+    id: string
+    genesisHash: Hash256
+    daoTypeHash: Hash256 | null
+    secp256k1Blake160SighashAllTypeHash: Hash256 | null
+    secp256k1Blake160MultisigAllTypeHash: Hash256 | null
+    initialPrimaryEpochReward: Capacity
+    secondaryEpochReward: Capacity
+    maxUnclesNum: string
+    orphanRateTarget: RationalU256
+    epochDurationTarget: string
+    txProposalWindow: ProposalWindow
+    proposerRewardRatio: RationalU256
+    cellbaseMaturity: EpochNumberWithFraction
+    medianTimeBlockCount: Count
+    maxBlockCycles: Cycles
+    maxBlockBytes: string
+    blockVersion: Version
+    txVersion: Version
+    typeIdCodeHash: Hash256
+    maxBlockProposalsLimit: string
+    primaryEpochRewardHalvingInterval: string
+    permanentDifficultyInDummy: boolean
   }
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -23,5 +23,5 @@
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs ./index.d.ts --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default --readme README.md"
   },
-  "gitHead": "919d9b9eeecca2e65e4e3fdb49763401a62a46bd"
+  "gitHead": "94af87551108a40f79c1cead0db5d3cc5c679302"
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.38.2",
+  "version": "0.39.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,9 +4291,9 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     minimalistic-assert "^1.0.1"
 
 highlight.js@^10.0.0:
-  version "10.2.1"
-  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-10.2.1.tgz#09784fe2e95612abbefd510948945d4fe6fa9668"
-  integrity sha512-A+sckVPIb9zQTUydC9lpRX1qRFO/N0OKEh0NwIr65ckvWA/oMY8v9P3+kGRK3w2ULSh9E8v5MszXafodQ6039g==
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
+  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4182,7 +4182,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
 
 growly@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.7.6:
@@ -4670,7 +4670,7 @@ is-directory@^0.3.1:
 
 is-docker@^2.0.0:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
@@ -4845,7 +4845,7 @@ is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
 
 is-wsl@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
@@ -4857,7 +4857,7 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
@@ -5706,6 +5706,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 lunr@^2.3.8:
   version "2.3.9"
   resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
@@ -6196,9 +6203,9 @@ node-modules-regexp@^1.0.0:
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-notifier@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz#a7eee2d51da6d0f7ff5094bc7108c911240c1620"
-  integrity sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
   dependencies:
     growly "^1.3.0"
     is-wsl "^2.2.0"
@@ -7465,9 +7472,11 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.2.1, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -7534,7 +7543,7 @@ shelljs@^0.8.4:
 
 shellwords@^0.1.1:
   version "0.1.1"
-  resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
@@ -8485,9 +8494,9 @@ uuid@^3.0.1, uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 uuid@^8.3.0:
-  version "8.3.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"
@@ -8787,6 +8796,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,12 +1979,12 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@0.19.2:
-  version "0.19.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+axios@0.21.1:
+  version "0.21.1"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.10.0"
 
 babel-jest@^26.5.2:
   version "26.5.2"
@@ -2990,7 +2990,7 @@ dateformat@^3.0.0:
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3844,12 +3844,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4495,9 +4495,9 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
+  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
 
 iniparser@~1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# [0.39.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.38.2...v0.39.0) (2021-01-13)


### Features

* **rpc:** add rpc#getRawTxPool, rpc#getConsensus and deprecate rpc#getCellbaseOutputCapacityDetails, rpc#getPeersState ([#528](https://github.com/nervosnetwork/ckb-sdk-js/pull/528))