### PR TITLE
reinforce restriction of generating and parsing address

### DIFF
--- a/packages/ckb-sdk-utils/__tests__/address/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/address/fixtures.json
@@ -141,8 +141,8 @@
       "expected": [4, 24, 146, 234, 64, 216, 43, 83, 198, 120, 255, 136, 49, 36, 80, 187, 177, 126, 22, 77, 122, 62, 10, 144, 148, 26, 165, 136, 57, 245, 111, 141, 242, 54, 195, 41, 237, 99, 13, 108, 231, 80, 113, 42, 71, 117, 67, 103, 42, 218, 181, 127, 76]
     },
     "full version address identifies the hash_type": {
-      "params": ["ckt1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vqgqza8m903wt5xp5wuxjnurydg2x0qksh280gxqzqgutrqyp"],
-      "expected": [0, 52, 25, 161, 192, 158, 178, 86, 127, 101, 82, 238, 122, 142, 207, 253, 100, 21, 92, 255, 224, 241, 121, 110, 110, 97, 236, 8, 141, 116, 12, 19, 86, 1, 0, 23, 79, 178, 190, 46, 93, 12, 26, 59, 134, 148, 248, 50, 53, 10, 51, 193, 104, 93, 71, 122, 12, 1, 1]
+      "params": ["ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqj0k2lzuhgvrgacvxtrw69"],
+      "expected": [0, 155, 215, 224, 111, 62, 207, 75, 224, 242, 252, 210, 24, 139, 35, 241, 185, 252, 200, 142, 93, 75, 101, 168, 99, 123, 23, 114, 59, 189, 163, 204, 232, 2, 79, 178, 190, 46, 93, 12, 26, 59, 134]
     },
     "should throw an error when short version address has invalid payload size": {
       "params": ["ckt1qyqrdsefa43s6m882pcj53m4gdnj4k440axqqm65l9j"],
@@ -152,11 +152,7 @@
       "params": ["ckt1qyprdsefa43s6m882pcj53m4gdnj4k440axqqfmyd9c"],
       "exception": "'ckt1qyprdsefa43s6m882pcj53m4gdnj4k440axqqfmyd9c' is not a valid short version address"
     },
-    "should throw an error when address type is invalid": {
-      "params": ["ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2"],
-      "exception": "'ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2' is not a valid address"
-    },
-    "should throw an error when hash type is invalid": {
+    "should throw an error when deprecated address's address type format 0x03 is invalid": {
       "params": ["ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2"],
       "exception": "'ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2' is not a valid address"
     },
@@ -168,13 +164,29 @@
       "params": ["ckb1qsqcjt4ypkpt20r83lugxyj9pwa30cty6737p2gfgx493qul2cgvrxhw"],
       "exception": "'ckb1qsqcjt4ypkpt20r83lugxyj9pwa30cty6737p2gfgx493qul2cgvrxhw' is not a valid full version address"
     },
-    "should throw an error when full version address identifies the hash_type has invalid code hash": {
-      "params": ["ckb1qqv6rsy7kft87e2jaeaganlavs24ellq79ukumnpasyg6aqvzdtqzukxep"],
-      "exception": "'ckb1qqv6rsy7kft87e2jaeaganlavs24ellq79ukumnpasyg6aqvzdtqzukxep' is not a valid address"
+    "should throw an error when full version address identifies the hash_type has invalid code hash(bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8)": {
+      "params": ["ckt1qq9a0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsjzla0h"],
+      "exception": "'ckt1qq9a0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsjzla0h' is not a valid address"
     },
-    "should throw an error when full version address identifies the hash_type has invalid hash type": {
-      "params": ["ckb1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vqcqza8m903wt5xp5wuxjnurydg2x0qksh280gxqzqgaxsc2r"],
-      "exception": "'ckb1qq6pngwqn6e9vlm92th84rk0l4jp2h8lurchjmnwv8kq3rt5psf4vqcqza8m903wt5xp5wuxjnurydg2x0qksh280gxqzqgaxsc2r' is not a valid address"
+    "should throw an error when full version address invalid hash_type 0x03 is invalid": {
+      "params": ["ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqcvf0k9sc40s3azmpfvhyuudhahpsj72tseeza5p"],
+      "exception": "'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqcvf0k9sc40s3azmpfvhyuudhahpsj72tseeza5p' is not a valid address"
+    },
+    "should throw an error when address format type is 0x00 but encode method is bech32": {
+      "params": ["ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq20k2lzuhgvrgacv4tmr88"],
+      "exception": "Address format type 0x00 doesn't match encode method bech32"
+    },
+    "should throw an error when address format type is 0x01 but encode method is bech32m": {
+      "params": ["ckb1qyqylv479ewscx3ms620sv34pgeuz6zagaaqh0knz7"],
+      "exception": "Address format type 0x01 doesn't match encode method bech32m"
+    },
+    "should throw an error when address format type is 0x02 but encode method is bech32m": {
+      "params": ["ckb1q2da0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsnajhch96rq68wrqn2tmhm"],
+      "exception": "Address format type 0x02 doesn't match encode method bech32m"
+    },
+    "should throw an error when address format type is 0x04 but encode method is bech32m": {
+      "params": ["ckt1qjda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsrzta3vx9tuy0gkc2t9e88rdldcvyhjjuguz6rt"],
+      "exception": "Address format type 0x04 doesn't match encode method bech32m"
     }
   },
   "addressToScript": {

--- a/packages/ckb-sdk-utils/__tests__/address/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/address/fixtures.json
@@ -31,6 +31,10 @@
     "should throw an error when its a full version address but hash_type is missing while code hash is not secp256k1 code hash": {
       "params": ["0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64", "0x00", "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3ccee"],
       "exception": "hashType is required"
+    },
+    "should throw an error when address format type is invalid(0x03)": {
+      "params": ["0x36c329ed630d6ce750712a477543672adab57f4c", "0x03", "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8"],
+      "exception": "0x03 is not a valid address format type"
     }
   },
   "fullPayloadToAddress": {
@@ -152,7 +156,7 @@
       "params": ["ckt1qyprdsefa43s6m882pcj53m4gdnj4k440axqqfmyd9c"],
       "exception": "'ckt1qyprdsefa43s6m882pcj53m4gdnj4k440axqqfmyd9c' is not a valid short version address"
     },
-    "should throw an error when deprecated address's address type format 0x03 is invalid": {
+    "should throw an error when deprecated address has invalid address type format 0x03": {
       "params": ["ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2"],
       "exception": "'ckt1qwn9dutjk669cfznq7httfar0gtk7qp0du3wjfvzck9l0w3k9eqhvdkr98kkxrtvuag8z2j8w4pkw2k6k4l5ctv25r2' is not a valid address"
     },
@@ -164,11 +168,11 @@
       "params": ["ckb1qsqcjt4ypkpt20r83lugxyj9pwa30cty6737p2gfgx493qul2cgvrxhw"],
       "exception": "'ckb1qsqcjt4ypkpt20r83lugxyj9pwa30cty6737p2gfgx493qul2cgvrxhw' is not a valid full version address"
     },
-    "should throw an error when full version address identifies the hash_type has invalid code hash(bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8)": {
+    "should throw an error when full version address has invalid code hash(bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8)": {
       "params": ["ckt1qq9a0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsjzla0h"],
       "exception": "'ckt1qq9a0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsjzla0h' is not a valid address"
     },
-    "should throw an error when full version address invalid hash_type 0x03 is invalid": {
+    "should throw an error when full version address has invalid hash_type 0x03": {
       "params": ["ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqcvf0k9sc40s3azmpfvhyuudhahpsj72tseeza5p"],
       "exception": "'ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqcvf0k9sc40s3azmpfvhyuudhahpsj72tseeza5p' is not a valid address"
     },

--- a/packages/ckb-sdk-utils/__tests__/exceptions/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/exceptions/fixtures.json
@@ -62,6 +62,13 @@
       "message": "'0x03' is not a valid hash type"
     }
   },
+  "AddressFormatTypeException": {
+    "params": [3],
+    "expected": {
+      "code": 104,
+      "message": "0x03 is not a valid address format type"
+    }
+  },
   "OutLenTooSmallException": {
     "params": [16, 32],
     "expected": {

--- a/packages/ckb-sdk-utils/__tests__/exceptions/fixtures.json
+++ b/packages/ckb-sdk-utils/__tests__/exceptions/fixtures.json
@@ -69,6 +69,13 @@
       "message": "0x03 is not a valid address format type"
     }
   },
+  "AddressFormatTypeAndEncodeMethodNotMatchException": {
+    "params": [3, "bech32"],
+    "expected": {
+      "code": 104,
+      "message": "Address format type 0x03 doesn't match encode method bech32"
+    }
+  },
   "OutLenTooSmallException": {
     "params": [16, 32],
     "expected": {

--- a/packages/ckb-sdk-utils/src/address/index.ts
+++ b/packages/ckb-sdk-utils/src/address/index.ts
@@ -109,6 +109,12 @@ export const toAddressPayload = (
     throw new HexStringWithout0xException(args)
   }
 
+  if (
+    ![AddressType.HashIdx, AddressType.DataCodeHash, AddressType.TypeCodeHash, AddressType.FullVersion].includes(type)
+  ) {
+    throw new AddressFormatTypeException(+type)
+  }
+
   if ([AddressType.DataCodeHash, AddressType.TypeCodeHash].includes(type)) {
     /* eslint-disable max-len */
     console.warn(

--- a/packages/ckb-sdk-utils/src/exceptions/address.ts
+++ b/packages/ckb-sdk-utils/src/exceptions/address.ts
@@ -39,9 +39,18 @@ export class HashTypeException extends Error {
   }
 }
 
+export class AddressFormatTypeException extends Error {
+  code = ErrorCode.AddressInvalid
+
+  constructor(type: number) {
+    super(`0x${type.toString(16).padStart(2, '0')} is not a valid address format type`)
+  }
+}
+
 export default {
   AddressPayloadException,
   AddressException,
   CodeHashException,
   HashTypeException,
+  AddressFormatTypeException,
 }

--- a/packages/ckb-sdk-utils/src/exceptions/address.ts
+++ b/packages/ckb-sdk-utils/src/exceptions/address.ts
@@ -47,10 +47,19 @@ export class AddressFormatTypeException extends Error {
   }
 }
 
+export class AddressFormatTypeAndEncodeMethodNotMatchException extends Error {
+  code = ErrorCode.AddressInvalid
+
+  constructor(type: number, bech32Type: 'bech32' | 'bech32m' | 'unknown' = 'unknown') {
+    super(`Address format type 0x${type.toString(16).padStart(2, '0')} doesn't match encode method ${bech32Type}`)
+  }
+}
+
 export default {
   AddressPayloadException,
   AddressException,
   CodeHashException,
   HashTypeException,
   AddressFormatTypeException,
+  AddressFormatTypeAndEncodeMethodNotMatchException,
 }


### PR DESCRIPTION
1. refactor utils.addressToScript for robustness
2. bech32m is required when address format type is 0x00
3. bech32 is required when address format type in [0x01, 0x02, 0x04]
4. limit address format type to 0x00, 0x01, 0x02, 0x04 in deprecated address generating method.